### PR TITLE
Adds _extended_purview attribute to Causal Links + pretty formatting of extended_purview

### DIFF
--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -413,20 +413,19 @@ class Transition:
             return CausalLink(max_ria)
         else:
             # Finds rias with maximum alpha
-            all_ria = [self.find_mip(direction, mechanism, purview,allow_neg)
-                          for purview in purviews]
+            all_ria = [self.find_mip(direction, mechanism, purview, allow_neg)
+                       for purview in purviews]
             max_alpha = max(all_ria).alpha
-            max_rias = [ria for ria in all_ria if ria.alpha==max_alpha]
+            max_rias = [ria for ria in all_ria if ria.alpha == max_alpha]
 
             # Selected rias whose purview is not a superset of any other
+            def is_not_superset(purview):
+                return np.all([(not set(purview).issuperset(set(purview2))) or
+                               (set(purview) == set(purview2)) for purview2 in purviews])
+                               
             purviews = [ria.purview for ria in max_rias]
-            extended_purview = []
-            for purview in purviews:
-                is_not_superset = not np.any([set(purview).issuperset(set(purview2)) and
-                    set(purview) > set(purview2) for purview2 in purviews])
-                if is_not_superset:
-                    extended_purview.append(purview)
-            return CausalLink(max(max_rias),tuple(extended_purview))
+            extended_purview = filter(is_not_superset, purviews)
+            return CausalLink(max(max_rias), tuple(extended_purview))
 
     def find_actual_cause(self, mechanism, purviews=False):
         """Return the actual cause of a mechanism."""

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -410,6 +410,7 @@ class Transition:
         if not purviews:
             max_ria = _null_ac_ria(self.mechanism_state(direction),
                                    direction, mechanism, None)
+            return CausalLink(max_ria)
         else:
             # Finds rias with maximum alpha
             all_ria = [self.find_mip(direction, mechanism, purview,allow_neg)
@@ -430,7 +431,7 @@ class Transition:
             causal_link = CausalLink(max(max_rias))
             causal_link._extended_purview = tuple(extended_purview)
             causal_link._ria._extended_purview = tuple(extended_purview)
-        return causal_link
+            return causal_link
 
     def find_actual_cause(self, mechanism, purviews=False):
         """Return the actual cause of a mechanism."""

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -413,9 +413,9 @@ class Transition:
             return CausalLink(max_ria)
 
         # Finds rias with maximum alpha
-        all_ria = [self.find_mip(direction, mechanism, purview, allow_neg)
+        all_ria = [self.find_mip(direction, mechanism, purview, allow_neg=allow_neg)
                    for purview in purviews]
-        max_ria = max(all_rias)
+        max_ria = max(all_ria)
         purviews = [ria.purview for ria in all_ria if ria.alpha == max_ria.alpha]
         # Selected rias whose purview is not a superset of any other
         def is_not_superset(purview):

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -418,12 +418,12 @@ class Transition:
             max_alpha = max(all_ria).alpha
             max_rias = [ria for ria in all_ria if ria.alpha == max_alpha]
 
+            purviews = [ria.purview for ria in max_rias]
             # Selected rias whose purview is not a superset of any other
             def is_not_superset(purview):
-                return np.all([(not set(purview).issuperset(set(purview2))) or
-                               (set(purview) == set(purview2)) for purview2 in purviews])
-                               
-            purviews = [ria.purview for ria in max_rias]
+                return any((set(purview).issuperset(set(other_purview))) and
+                           (set(purview) != set(other_purview)) for other_purview in purviews)
+                           
             extended_purview = filter(is_not_superset, purviews)
             return CausalLink(max(max_rias), tuple(extended_purview))
 

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -421,9 +421,9 @@ class Transition:
             purviews = [ria.purview for ria in max_rias]
             # Selected rias whose purview is not a superset of any other
             def is_not_superset(purview):
-                return any((set(purview).issuperset(set(other_purview))) and
-                           (set(purview) != set(other_purview)) for other_purview in purviews)
-                           
+                return all((not set(purview).issuperset(set(other_purview))) or
+                           (set(purview) == set(other_purview)) for other_purview in purviews)
+
             extended_purview = filter(is_not_superset, purviews)
             return CausalLink(max(max_rias), tuple(extended_purview))
 

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -426,12 +426,7 @@ class Transition:
                     set(purview) > set(purview2) for purview2 in purviews])
                 if is_not_superset:
                     extended_purview.append(purview)
-
-            # Construct the corresponding CausalLink including all equivalent purviews in hidden attribute
-            causal_link = CausalLink(max(max_rias))
-            causal_link._extended_purview = tuple(extended_purview)
-            causal_link._ria._extended_purview = tuple(extended_purview)
-            return causal_link
+            return CausalLink(max(max_rias),tuple(extended_purview))
 
     def find_actual_cause(self, mechanism, purviews=False):
         """Return the actual cause of a mechanism."""

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -415,17 +415,15 @@ class Transition:
             # Finds rias with maximum alpha
             all_ria = [self.find_mip(direction, mechanism, purview, allow_neg)
                        for purview in purviews]
-            max_alpha = max(all_ria).alpha
-            max_rias = [ria for ria in all_ria if ria.alpha == max_alpha]
-
-            purviews = [ria.purview for ria in max_rias]
+            max_ria = max(all_rias)
+            purviews = [ria.purview for ria in all_ria if ria.alpha == max_ria.alpha]
             # Selected rias whose purview is not a superset of any other
             def is_not_superset(purview):
                 return all((not set(purview).issuperset(set(other_purview))) or
                            (set(purview) == set(other_purview)) for other_purview in purviews)
 
             extended_purview = filter(is_not_superset, purviews)
-            return CausalLink(max(max_rias), tuple(extended_purview))
+            return CausalLink(max_ria, tuple(extended_purview))
 
     def find_actual_cause(self, mechanism, purviews=False):
         """Return the actual cause of a mechanism."""

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -411,19 +411,19 @@ class Transition:
             max_ria = _null_ac_ria(self.mechanism_state(direction),
                                    direction, mechanism, None)
             return CausalLink(max_ria)
-        else:
-            # Finds rias with maximum alpha
-            all_ria = [self.find_mip(direction, mechanism, purview, allow_neg)
-                       for purview in purviews]
-            max_ria = max(all_rias)
-            purviews = [ria.purview for ria in all_ria if ria.alpha == max_ria.alpha]
-            # Selected rias whose purview is not a superset of any other
-            def is_not_superset(purview):
-                return all((not set(purview).issuperset(set(other_purview))) or
-                           (set(purview) == set(other_purview)) for other_purview in purviews)
 
-            extended_purview = filter(is_not_superset, purviews)
-            return CausalLink(max_ria, tuple(extended_purview))
+        # Finds rias with maximum alpha
+        all_ria = [self.find_mip(direction, mechanism, purview, allow_neg)
+                   for purview in purviews]
+        max_ria = max(all_rias)
+        purviews = [ria.purview for ria in all_ria if ria.alpha == max_ria.alpha]
+        # Selected rias whose purview is not a superset of any other
+        def is_not_superset(purview):
+            return all((not set(purview).issuperset(set(other_purview))) or
+                       (set(purview) == set(other_purview)) for other_purview in purviews)
+
+        extended_purview = filter(is_not_superset, purviews)
+        return CausalLink(max_ria, tuple(extended_purview))
 
     def find_actual_cause(self, mechanism, purviews=False):
         """Return the actual cause of a mechanism."""

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -426,9 +426,10 @@ class Transition:
                 if is_not_superset:
                     extended_purview.append(purview)
 
-            # Construct the corresponding CausalLink including all equivalent purviews
+            # Construct the corresponding CausalLink including all equivalent purviews in hidden attribute
             causal_link = CausalLink(max(max_rias))
             causal_link._extended_purview = tuple(extended_purview)
+            causal_link._ria._extended_purview = tuple(extended_purview)
         return causal_link
 
     def find_actual_cause(self, mechanism, purviews=False):

--- a/pyphi/actual.py
+++ b/pyphi/actual.py
@@ -426,13 +426,9 @@ class Transition:
                 if is_not_superset:
                     extended_purview.append(purview)
 
-            max_ria = max(max_rias)
-
             # Construct the corresponding CausalLink including all equivalent purviews
-            causal_link = CausalLink(max_ria)
+            causal_link = CausalLink(max(max_rias))
             causal_link._extended_purview = tuple(extended_purview)
-
-
         return causal_link
 
     def find_actual_cause(self, mechanism, purviews=False):

--- a/pyphi/models/actual_causation.py
+++ b/pyphi/models/actual_causation.py
@@ -133,7 +133,7 @@ class CausalLink(cmp.Orderable):
 
     def __init__(self, ria, extended_purview=None):
         self._ria = ria
-        self._extended_purview = extended_purview
+        self._extended_purview = tuple(extended_purview)
 
     @property
     def alpha(self):

--- a/pyphi/models/actual_causation.py
+++ b/pyphi/models/actual_causation.py
@@ -133,7 +133,7 @@ class CausalLink(cmp.Orderable):
 
     def __init__(self, ria, extended_purview=None):
         self._ria = ria
-        self._extended_purview = tuple(extended_purview)
+        self._extended_purview = tuple(extended_purview) if extended_purview is not None else None
 
     @property
     def alpha(self):
@@ -168,8 +168,10 @@ class CausalLink(cmp.Orderable):
     def extended_purview(self):
         """tuple[tuple[int]]: List of purviews over which this causal link is
         maximally irreducible.
+
         Note: It will contain multiple purviews iff causal link has
-        undetermined actual causes/effects.
+        undetermined actual causes/effects (e.g. two irreducible causes with same alpha
+        over different purviews).
         """
         return self._extended_purview
 

--- a/pyphi/models/actual_causation.py
+++ b/pyphi/models/actual_causation.py
@@ -166,10 +166,10 @@ class CausalLink(cmp.Orderable):
 
     @property
     def extended_purview(self):
-        """tuple of tuple[int]: List of purviews over which this causal link is
+        """tuple[tuple[int]]: List of purviews over which this causal link is
         (equivalently) maximally irreducible.
-        Note: It is reducible to the purview unless the causal link has undetermined
-        causes/effect."""
+        Note: It is reducible to the purview unless the causal link has
+        undetermined causes/effect."""
         return self._extended_purview
 
     @property
@@ -184,7 +184,7 @@ class CausalLink(cmp.Orderable):
         return self._ria.node_labels
 
     def __repr__(self):
-        return fmt.make_repr(self, ['ria','extended_purview'])
+        return fmt.make_repr(self, ['ria', 'extended_purview'])
 
     def __str__(self):
         return "CausalLink\n" + fmt.indent(fmt.fmt_causal_link(self))

--- a/pyphi/models/actual_causation.py
+++ b/pyphi/models/actual_causation.py
@@ -166,7 +166,10 @@ class CausalLink(cmp.Orderable):
 
     @property
     def extended_purview(self):
-        """tuple of tuple[int]: List of purviews over which this causal link is equivalentymaximally irreducible."""
+        """tuple of tuple[int]: List of purviews over which this causal link is
+        (equivalently) maximally irreducible.
+        Note: It is reducible to the purview unless the causal link has undetermined
+        causes/effect."""
         return self._extended_purview
 
     @property

--- a/pyphi/models/actual_causation.py
+++ b/pyphi/models/actual_causation.py
@@ -167,9 +167,10 @@ class CausalLink(cmp.Orderable):
     @property
     def extended_purview(self):
         """tuple[tuple[int]]: List of purviews over which this causal link is
-        (equivalently) maximally irreducible.
-        Note: It is reducible to the purview unless the causal link has
-        undetermined causes/effect."""
+        maximally irreducible.
+        Note: It will contain multiple purviews iff causal link has
+        undetermined actual causes/effects.
+        """
         return self._extended_purview
 
     @property

--- a/pyphi/models/actual_causation.py
+++ b/pyphi/models/actual_causation.py
@@ -131,8 +131,9 @@ class CausalLink(cmp.Orderable):
     up to |PRECISION|, the size of the mechanism is compared.
     """
 
-    def __init__(self, ria):
+    def __init__(self, ria, extended_purview=None):
         self._ria = ria
+        self._extended_purview = extended_purview
 
     @property
     def alpha(self):
@@ -164,6 +165,11 @@ class CausalLink(cmp.Orderable):
         return self._ria.purview
 
     @property
+    def extended_purview(self):
+        """tuple of tuple[int]: List of purviews over which this causal link is equivalentymaximally irreducible."""
+        return self._extended_purview
+
+    @property
     def ria(self):
         """AcRepertoireIrreducibilityAnalysis: The irreducibility analysis for
         this mechanism.
@@ -175,10 +181,10 @@ class CausalLink(cmp.Orderable):
         return self._ria.node_labels
 
     def __repr__(self):
-        return fmt.make_repr(self, ['ria'])
+        return fmt.make_repr(self, ['ria','extended_purview'])
 
     def __str__(self):
-        return "CausalLink\n" + fmt.indent(fmt.fmt_ac_ria(self.ria))
+        return "CausalLink\n" + fmt.indent(fmt.fmt_causal_link(self))
 
     unorderable_unless_eq = \
         AcRepertoireIrreducibilityAnalysis.unorderable_unless_eq

--- a/pyphi/models/fmt.py
+++ b/pyphi/models/fmt.py
@@ -458,7 +458,6 @@ def fmt_ac_ria(ria):
         alpha=round(ria.alpha, 4),
         causality=causality)
 
-
 def fmt_account(account, title=None):
     """Format an Account or a DirectedAccount."""
     if title is None:

--- a/pyphi/models/fmt.py
+++ b/pyphi/models/fmt.py
@@ -427,24 +427,31 @@ def fmt_repertoire(r):
 
 def fmt_extended_purview(extended_purview, node_labels=None):
     """Format an extended purview."""
-    purviews = [fmt_mechanism(purview, node_labels) for purview in extended_purview]
-    return '[' + ', '.join(purviews) + ']'
+    if len(extended_purview)==1:
+        return fmt_mechanism(extended_purview[0], node_labels=node_labels)
+
+    else:
+        purviews = [fmt_mechanism(purview, node_labels=node_labels) for purview in extended_purview]
+        return '[' + ', '.join(purviews) + ']'
+
 
 def fmt_causal_link(causal_link):
     """Format a CausalLink."""
-    return fmt_ac_ria(causal_link, causal_link.extended_purview)
+    return fmt_ac_ria(causal_link, extended_purview=causal_link.extended_purview)
 
 def fmt_ac_ria(ria, extended_purview=None):
     """Format an AcRepertoireIrreducibilityAnalysis."""
     causality = {
-        Direction.CAUSE: (fmt_mechanism(ria.purview, ria.node_labels) if extended_purview is None
-                        else fmt_extended_purview(ria._extended_purview, ria.node_labels),
+        Direction.CAUSE: (fmt_mechanism(ria.purview, ria.node_labels)
+                          if extended_purview is None
+                          else fmt_extended_purview(ria.extended_purview, ria.node_labels),
                           ARROW_LEFT,
                           fmt_mechanism(ria.mechanism, ria.node_labels)),
         Direction.EFFECT: (fmt_mechanism(ria.mechanism, ria.node_labels),
                            ARROW_RIGHT,
-                           fmt_mechanism(ria.purview, ria.node_labels) if extended_purview is None
-                        else fmt_extended_purview(ria._extended_purview, ria.node_labels))
+                           fmt_mechanism(ria.purview, ria.node_labels)
+                           if extended_purview is None
+                           else fmt_extended_purview(ria.extended_purview, ria.node_labels))
     }[ria.direction]
     causality = ' '.join(causality)
 

--- a/pyphi/models/fmt.py
+++ b/pyphi/models/fmt.py
@@ -425,17 +425,32 @@ def fmt_repertoire(r):
 
     return box('\n'.join(lines))
 
+def fmt_extended_purview(extended_purview, node_labels=None):
+    """Format an extended purview (multiple purviews."""
+    purviews = [fmt_mechanism(purview, node_labels) for purview in extended_purview]
+    return '[' + ', '.join(purviews) + ']'
 
 def fmt_ac_ria(ria):
     """Format an AcRepertoireIrreducibilityAnalysis."""
-    causality = {
-        Direction.CAUSE: (fmt_mechanism(ria.purview, ria.node_labels),
-                          ARROW_LEFT,
-                          fmt_mechanism(ria.mechanism, ria.node_labels)),
-        Direction.EFFECT: (fmt_mechanism(ria.mechanism, ria.node_labels),
-                           ARROW_RIGHT,
-                           fmt_mechanism(ria.purview, ria.node_labels))
-    }[ria.direction]
+    if hasattr(ria, '_extended_purview') and len(ria._extended_purview)>1:
+        causality = {
+            Direction.CAUSE: (fmt_extended_purview(ria._extended_purview, ria.node_labels),
+                              ARROW_LEFT,
+                              fmt_mechanism(ria.mechanism, ria.node_labels)),
+            Direction.EFFECT: (fmt_mechanism(ria.mechanism, ria.node_labels),
+                               ARROW_RIGHT,
+                               fmt_extended_purview(ria._extended_purview, ria.node_labels))
+        }[ria.direction]
+
+    else:
+        causality = {
+            Direction.CAUSE: (fmt_mechanism(ria.purview, ria.node_labels),
+                              ARROW_LEFT,
+                              fmt_mechanism(ria.mechanism, ria.node_labels)),
+            Direction.EFFECT: (fmt_mechanism(ria.mechanism, ria.node_labels),
+                               ARROW_RIGHT,
+                               fmt_mechanism(ria.purview, ria.node_labels))
+        }[ria.direction]
     causality = ' '.join(causality)
 
     return '{ALPHA} = {alpha}  {causality}'.format(

--- a/pyphi/models/fmt.py
+++ b/pyphi/models/fmt.py
@@ -427,12 +427,11 @@ def fmt_repertoire(r):
 
 def fmt_extended_purview(extended_purview, node_labels=None):
     """Format an extended purview."""
-    if len(extended_purview)==1:
+    if len(extended_purview) == 1:
         return fmt_mechanism(extended_purview[0], node_labels=node_labels)
 
-    else:
-        purviews = [fmt_mechanism(purview, node_labels=node_labels) for purview in extended_purview]
-        return '[' + ', '.join(purviews) + ']'
+    purviews = [fmt_mechanism(purview, node_labels=node_labels) for purview in extended_purview]
+    return '[' + ', '.join(purviews) + ']'
 
 
 def fmt_causal_link(causal_link):

--- a/pyphi/utils.py
+++ b/pyphi/utils.py
@@ -198,7 +198,7 @@ def load_data(directory, num):
     def get_path(i):  # pylint: disable=missing-docstring
         return os.path.join(root, 'data', directory, str(i) + '.npy')
 
-    return [np.load(get_path(i)) for i in range(num)]
+    return [np.load(get_path(i), allow_pickle=True) for i in range(num)]
 
 
 # Using ``decorator`` preserves the function signature of the wrapped function,


### PR DESCRIPTION
In actual causation, when computing causal links, it often occurs that purviews have the same alpha. Currently, the `find_causal_link()` method returns one arbitrary purview from the ones with maximum alpha.
The `find_causal_link()` method now adds a hidden attribute `_extended_purview` to the returned `CausalLink` with all the purviews with equivalent maximum alpha which are not supersets of each other. For example, if purviews (A,B), (B,C), (A,B,D) have the same maximum alpha, the extended purview is ((A,B),(B,C)).

I've also added pretty formatting methods to print the CausalLinks when they have extended purviews so they look like:
α = 0.415  [[S1, A], [A, D]] ◀━━ [M1]