### PR TITLE
visualize: from collections.abc import Iterable

### DIFF
--- a/pyphi/visualize.py
+++ b/pyphi/visualize.py
@@ -1,4 +1,5 @@
-from collections import Iterable, defaultdict
+from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from itertools import combinations
 from math import cos, isclose, radians, sin


### PR DESCRIPTION
Iterable can no longer be found directly in collections as of python 3.10. Most source code is up-to-date with this, except for this file.