### PR TITLE
test_big_phi: Utilize IIT 3.0 config fixture

### DIFF
--- a/test/test_big_phi.py
+++ b/test/test_big_phi.py
@@ -228,7 +228,7 @@ def test_sia_cache_key_includes_config_dependencies(s):
     assert l1_big_phi != emd_big_phi
 
 
-def test_clear_subsystem_caches_after_computing_sia_config_option(s):
+def test_clear_subsystem_caches_after_computing_sia_config_option(use_iit_3_config, s):
     with config.override(
         CLEAR_SUBSYSTEM_CACHES_AFTER_COMPUTING_SIA=False,
         PARALLEL_CONCEPT_EVALUATION=False,

--- a/test/test_compute_network.py
+++ b/test/test_compute_network.py
@@ -34,7 +34,7 @@ def test_all_complexes_standard(s):
 
 
 @config.override(PARALLEL_CUT_EVALUATION=False)
-def test_all_complexes_parallelization(s):
+def test_all_complexes_parallelization(use_iit_3_config, s):
     with config.override(PARALLEL_COMPLEX_EVALUATION=False):
         serial = compute.network.all_complexes(s.network, s.state)
 

--- a/test/test_compute_network.py
+++ b/test/test_compute_network.py
@@ -34,7 +34,7 @@ def test_all_complexes_standard(s):
 
 
 @config.override(PARALLEL_CUT_EVALUATION=False)
-def test_all_complexes_parallelization(use_iit_3_config, s):
+def test_all_complexes_parallelization(s):
     with config.override(PARALLEL_COMPLEX_EVALUATION=False):
         serial = compute.network.all_complexes(s.network, s.state)
 

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -50,7 +50,7 @@ def test_jsonify_numpy():
     assert answer == json.loads(jsonify.dumps(x))
 
 
-def test_json_deserialization(s, transition):
+def test_json_deserialization(use_iit_3_config, s, transition):
     objects = [
         Direction.CAUSE,
         s.network,  # Network
@@ -90,7 +90,7 @@ def test_json_deserialization_non_pyphi_clasess():
     assert loaded == {"x": 1}
 
 
-def test_deserialization_memoizes_duplicate_objects(s):
+def test_deserialization_memoizes_duplicate_objects(use_iit_3_config, s):
     with config.override(PARALLEL_CUT_EVALUATION=True):
         sia = compute.subsystem.sia(s)
 

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -50,7 +50,7 @@ def test_jsonify_numpy():
     assert answer == json.loads(jsonify.dumps(x))
 
 
-def test_json_deserialization(use_iit_3_config, s, transition):
+def test_json_deserialization(s, transition):
     objects = [
         Direction.CAUSE,
         s.network,  # Network
@@ -90,7 +90,7 @@ def test_json_deserialization_non_pyphi_clasess():
     assert loaded == {"x": 1}
 
 
-def test_deserialization_memoizes_duplicate_objects(use_iit_3_config, s):
+def test_deserialization_memoizes_duplicate_objects(s):
     with config.override(PARALLEL_CUT_EVALUATION=True):
         sia = compute.subsystem.sia(s)
 


### PR DESCRIPTION
`use_IIT_3_config` added to `test_big_phi.test_clear_subsystem_caches_after_computing_sia_config_option()`