### PR TITLE
Improved ExplicitTPM API and method semantics (now with array methods for free)

### DIFF
--- a/pyphi/network.py
+++ b/pyphi/network.py
@@ -176,7 +176,7 @@ class Network:
         """
         return (
             isinstance(other, Network)
-            and self.tpm == other.tpm
+            and self.tpm.array_equal(other.tpm)
             and np.array_equal(self.cm, other.cm)
         )
 

--- a/pyphi/network.py
+++ b/pyphi/network.py
@@ -176,7 +176,7 @@ class Network:
         """
         return (
             isinstance(other, Network)
-            and np.array_equal(self.tpm, other.tpm)
+            and self.tpm == other.tpm
             and np.array_equal(self.cm, other.cm)
         )
 

--- a/pyphi/node.py
+++ b/pyphi/node.py
@@ -137,7 +137,7 @@ class Node:
         """
         return (
             self.index == other.index
-            and self.tpm == other.tpm
+            and self.tpm.array_equal(other.tpm)
             and self.state == other.state
             and self.inputs == other.inputs
             and self.outputs == other.outputs

--- a/pyphi/subsystem.py
+++ b/pyphi/subsystem.py
@@ -38,6 +38,7 @@ from .models import (
 from .network import irreducible_purviews
 from .node import generate_nodes
 from .partition import mip_partitions
+from .tpm import ExplicitTPM
 from .utils import state_of
 
 log = logging.getLogger(__name__)
@@ -82,6 +83,7 @@ class Subsystem:
     ):
         # The network this subsystem belongs to.
         validate.is_network(network)
+        network._tpm = ExplicitTPM.enforce(network.tpm)
         self.network = network
 
         self.node_labels = network.node_labels
@@ -415,6 +417,7 @@ class Subsystem:
         # pylint: disable=missing-docstring
         purview_node = self._index2node[purview_node_index]
         # Condition on the state of the purview inputs that are in the mechanism
+        purview_node.tpm = ExplicitTPM.enforce(purview_node.tpm)
         tpm = purview_node.tpm.condition_tpm(condition)
         # TODO(4.0) remove reference to TPM
         # Marginalize-out the inputs that aren't in the mechanism.

--- a/pyphi/subsystem.py
+++ b/pyphi/subsystem.py
@@ -106,7 +106,6 @@ class Subsystem:
         # Get the TPM conditioned on the state of the external nodes.
         external_state = utils.state_of(self.external_indices, self.state)
         background_conditions = dict(zip(self.external_indices, external_state))
-        print(type(self.network.tpm))
         self.tpm = self.network.tpm.condition_tpm(background_conditions)
         # The TPM for just the nodes in the subsystem.
         self.proper_tpm = self.tpm.squeeze()[..., list(self.node_indices)]

--- a/pyphi/subsystem.py
+++ b/pyphi/subsystem.py
@@ -106,6 +106,7 @@ class Subsystem:
         # Get the TPM conditioned on the state of the external nodes.
         external_state = utils.state_of(self.external_indices, self.state)
         background_conditions = dict(zip(self.external_indices, external_state))
+        print(type(self.network.tpm))
         self.tpm = self.network.tpm.condition_tpm(background_conditions)
         # The TPM for just the nodes in the subsystem.
         self.proper_tpm = self.tpm.squeeze()[..., list(self.node_indices)]

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -470,6 +470,17 @@ class ExplicitTPM(Wrapper):
         """
         return isinstance(o, type(self)) and np.array_equal(self._tpm, o._tpm)
 
+    @classmethod
+    def enforce(cls, tpm: object):
+        """Create a new TPM object if necessary.
+
+        This acts as a partially applied ternary operator with the condition set
+        to type-checking the input.
+        """
+        if not isinstance(tpm, cls):
+            return ExplicitTPM(tpm, validate=False)
+        return tpm
+
     def __str__(self):
         return self.__repr__()
 

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -160,7 +160,7 @@ class ExplicitTPM(Wrapper):
                 args = tuple(args)
 
             # TODO attributes data, real and imag return arrays that should
-            # also be casted, even though they are not callable.
+            # also be cast, even though they are not callable.
             result = attribute(*args, **kwargs)
 
             # Test type of result. Reducing operations (e.g. sum(), max())

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -15,17 +15,261 @@ from .constants import OFF, ON
 from .data_structures import FrozenMap
 from .utils import all_states, np_hash, np_immutable
 
+class ProxyMetaclass(type):
+    """A metaclass to create wrappers for the TPM array's special attributes.
 
-class TPM:
-    """A transition probability matrix."""
+    The CPython interpreter resolves double-underscore attributes (e.g., the
+    method definitions of mathematical operators) by looking up in the class'
+    static methods, not in the instance methods. This makes it impossible to
+    intercept calls to them when an instance's __getattr__() is implicitly
+    invoked, which in turn means there are only two options to wrap the special
+    methods of the array inside our custom objects (in order to perform
+    arithmetic operations with the TPM while also casting the result to our
+    custom class type):
 
-    def __init__(self):
-        raise NotImplementedError
+    1. Manually "overload" all the necessary methods.
+    2. Use this metaclass to introspect the underlying array
+      and automatically overload methods in our custom TPM class definition.
+    """
+    def __init__(cls, type_name, bases, dct):
+
+        # Casting semantics: values belonging to our custom TPM class should
+        # remain closed under the following methods:
+        __closures__ = frozenset{
+            # 1-ary
+            "__abs__", "__copy__", "__invert__", "__neg__", "__pos__",
+            # 2-ary
+            "__add__", "__iadd__", "__radd__",
+            "__sub__", "__isub__", "__rsub__",
+            "__mul__", "__imul__", "__rmul__",
+            "__matmul__", "__imatmul__", "__rmatmul__",
+            "__truediv__", "__itruediv__", "__rtruediv__",
+            "__floordiv__", "__ifloordiv__", "__rfloordiv__",
+            "__mod__", "__imod__", "__rmod__",
+            "__and__", "__iand__", "__rand__",
+            "__lshift__", "__ilshift__", "__irshift__",
+            "__rlshift__", "__rrshift__", "__rshift__",
+            "__ior__", "__or__", "__ror__",
+            "__xor__", "__ixor__", "__rxor__",
+            # __eq__ and __ne__ are explicitly implemented
+            "__ge__", "__gt__", "__lt__", "__le__",
+            "__deepcopy__",
+            # 3-ary
+            "__pow__", "__ipow__", "__rpow__",
+            # 2-ary, 2-valued
+            "__divmod__", "__rdivmod__"
+        }
+
+        def make_proxy(name):
+            """Returns a function that acts as a proxy for the given method name.
+
+            Args:
+                name (str): The name of the method to introspect in self._tpm.
+
+            Returns:
+                function: The wrapping function.
+            """
+            def proxy(self):
+                attribute = getattr(self._tpm, name)
+
+                if not name in __closures__:
+                    return attribute
+
+                def overriding_attribute(*args):
+                    # If second operand is a custom TPM object, access its array.
+                    if args and isinstance(args[0], type(self)):
+                        args = list(args)
+                        args[0] = args[0]._tpm
+                        args = tuple(args)
+
+                    # Evaluate n-ary operator with self and rest of operands.
+                    result = attribute(*args)
+
+                    # Cast result to our custom TPM class.
+                    if isinstance(result, tuple):
+                        # Multivalued "functions" result in a tuple, e.g., the
+                        # 2-tuple (quotients, remainders) from __divmod__().
+                        return (type(self)(r, validate=False) for r in result)
+
+                    return type(self)(result, validate=False)
+
+                return overriding_attribute
+
+            return proxy
+
+        type.__init__(cls, type_name, bases, dct)
+
+        if cls.__wraps__:
+            ignore = cls.__ignore__
+            # Go through all the attribute strings in the wrapped array type.
+            for name in dir(cls.__wraps__):
+                # Filter special attributes. The rest will be handled by Wrapper.
+                if name.startswith("__") and name not in ignore and name not in dct:
+                    # Create proxy function for `name` and bind it to future
+                    # instances of cls.
+                    setattr(cls, name, property(make_proxy(name)))
+
+class Wrapper(metaclass=ProxyMetaclass):
+    """Proxy to the array inside PyPhi's custom TPM class.
+    """
+
+    __wraps__  = None
+    __ignore__ = {"class", "mro", "new", "init", "setattr", "getattr", "getattribute"}
+    __ignore__ = frozenset(f"__{i}__" for i in __ignore__)
+
+    def __init__(self, tpm):
+        if self.__wraps__ is None:
+            raise TypeError("Base class Wrapper may not be instantiated.")
+
+        if not isinstance(tpm, self.__wraps__):
+            raise ValueError(f"Wrapped object must be of type {self.__wraps__}")
+
+
+class ExplicitTPM(Wrapper):
+    """An explicit network TPM in multidimensional form."""
+
+    __wraps__ = np.ndarray
+
+    # Casting semantics: values belonging to our custom TPM class should
+    # remain closed under the following methods:
+    __closures__ =  frozenset{
+        "argpartition", "astype", "byteswap", "choose", "clip", "compress",
+        "conj", "conjugate", "copy", "cumprod", "cumsum", "diagonal", "dot",
+        "fill", "flatten", "getfield", "item", "itemset", "max", "mean", "min",
+        "newbyteorder", "partition", "prod", "ptp", "put", "ravel", "repeat",
+        "reshape", "resize", "round", "setfield", "sort", "squeeze", "std",
+        "sum", "swapaxes", "take", "transpose", "var", "view"
+    }
+
+    # Proxy access to regular attributes of the wrapped array.
+    def __getattr__(self, name):
+        # Fix error with serialization. TODO: Implement dumps(), tobytes()?
+        if "_tpm" not in vars(self):
+            raise AttributeError
+
+        attribute = getattr(self._tpm, name)
+
+        if name not in self.__closures__:
+            return attribute
+
+        def overriding_method(*args, **kwargs):
+            # If second operand is a custom TPM, use its array instead.
+            if args and isinstance(args[0], type(self)):
+                args = list(args)
+                args[0] = args[0]._tpm
+                args = tuple(args)
+
+            # TODO attributes data, real and imag return arrays that should
+            # also be casted, even though they are not callable.
+            result = attribute(*args, **kwargs)
+
+            # Test type of result. Reducing operations (e.g. sum(), max())
+            # return a scalar unless performed along an axis in a
+            # multidimensional array. Similarly, dot() may not return a scalar
+            # in general, because it is implemented in a polymorphic way.
+            if isinstance(result, self.__wraps__):
+                return type(self)(result, validate=False)
+
+            return result
+
+        # TODO search and replace return type.
+        overriding_method.__doc__ = attribute.__doc__
+
+        return overriding_method
+
+    def __init__(self, tpm, validate=True):
+        super().__init__(tpm)
+        self._tpm = np.array(tpm)
+
+        if validate:
+            self.validate(check_independence=config.VALIDATE_CONDITIONAL_INDEPENDENCE)
+            self._tpm = self.to_multidimensional_state_by_node()
+
+        self._tpm = np_immutable(self._tpm)
+        self._hash = np_hash(self._tpm)
 
     @property
     def tpm(self):
         """Return the underlying `tpm` object."""
         return self._tpm
+
+    def validate(self, check_independence=True):
+        """Validate this TPM."""
+        return self._validate_probabilities() and self._validate_shape(
+            check_independence
+        )
+
+    def _validate_probabilities(self):
+        """Check that the probabilities in a TPM are valid."""
+        if (self._tpm < 0.0).any() or (self._tpm > 1.0).any():
+            raise ValueError(
+                "Invalid TPM: probabilities must be in the interval [0, 1]."
+            )
+        if self.is_state_by_state() and np.any(np.sum(self._tpm, axis=1) != 1.0):
+            raise ValueError("Invalid TPM: probabilities must sum to 1.")
+        return True
+
+    def _validate_shape(self, check_independence=True):
+        """Validate this TPM's shape.
+
+        The TPM can be in
+
+            * 2-dimensional state-by-state form,
+            * 2-dimensional state-by-node form, or
+            * multidimensional state-by-node form.
+        """
+        see_tpm_docs = (
+            "See the documentation on TPM conventions and the `pyphi.Network` "
+            "object for more information on TPM forms."
+        )
+        tpm = self._tpm
+        # Get the number of nodes from the state-by-node TPM.
+        N = tpm.shape[-1]
+        if tpm.ndim == 2:
+            if not (
+                (tpm.shape[0] == 2 ** N and tpm.shape[1] == N)
+                or (tpm.shape[0] == tpm.shape[1])
+            ):
+                raise ValueError(
+                    "Invalid shape for 2-D TPM: {}\nFor a state-by-node TPM, "
+                    "there must be "
+                    "2^N rows and N columns, where N is the "
+                    "number of nodes. State-by-state TPM must be square. "
+                    "{}".format(tpm.shape, see_tpm_docs)
+                )
+            if tpm.shape[0] == tpm.shape[1] and check_independence:
+                self.conditionally_independent()
+        elif tpm.ndim == (N + 1):
+            if tpm.shape != tuple([2] * N + [N]):
+                raise ValueError(
+                    "Invalid shape for multidimensional state-by-node TPM: {}\n"
+                    "The shape should be {} for {} nodes. {}".format(
+                        tpm.shape, ([2] * N) + [N], N, see_tpm_docs
+                    )
+                )
+        else:
+            raise ValueError(
+                "Invalid TPM: Must be either 2-dimensional or multidimensional. "
+                "{}".format(see_tpm_docs)
+            )
+        return True
+
+    def to_multidimensional_state_by_node(self):
+        """Return the current TPM re-represented in multidimensional
+        state-by-node form.
+
+        See the PyPhi documentation on :ref:`tpm-conventions` for more
+        information.
+
+        Returns:
+            np.ndarray: The TPM in multidimensional state-by-node format.
+        """
+        if self.is_state_by_state():
+            tpm = convert.state_by_state2state_by_node(self._tpm)
+        else:
+            tpm = convert.to_multidimensional(self._tpm)
+
+        return tpm
 
     def conditionally_independent(self):
         """Validate that the TPM is conditionally independent."""
@@ -46,10 +290,6 @@ class TPM:
                 "for more info."
             )
         return True
-
-    def validate(self):
-        """Ensure the tpm is well-formed."""
-        raise NotImplementedError
 
     def condition_tpm(self, condition: FrozenMap[int, int]):
         """Return a TPM conditioned on the given fixed node indices, whose
@@ -215,118 +455,11 @@ class TPM:
             validate=False,
         )
 
-    def __getattr__(self, name):
-        if "_tpm" not in vars(self):
-            raise AttributeError
-        return getattr(self._tpm, name)
-
     def __getitem__(self, i):
         item = self._tpm[i]
         if isinstance(item, type(self._tpm)):
             item = type(self)(item, validate=False)
         return item
-
-    def __repr__(self):
-        raise NotImplementedError
-
-    def __str__(self):
-        return self.__repr__()
-
-
-class ExplicitTPM(TPM):
-    """An explicit network TPM in multidimensional form."""
-
-    def __init__(self, tpm, validate=True):
-        self._tpm = np.array(tpm)
-
-        if validate:
-            self.validate(check_independence=config.VALIDATE_CONDITIONAL_INDEPENDENCE)
-            self._tpm = self.to_multidimensional_state_by_node()
-
-        self._tpm = np_immutable(self._tpm)
-        self._hash = np_hash(self._tpm)
-
-    def _validate_shape(self, check_independence=True):
-        """Validate this TPM's shape.
-
-        The TPM can be in
-
-            * 2-dimensional state-by-state form,
-            * 2-dimensional state-by-node form, or
-            * multidimensional state-by-node form.
-        """
-        see_tpm_docs = (
-            "See the documentation on TPM conventions and the `pyphi.Network` "
-            "object for more information on TPM forms."
-        )
-        tpm = self._tpm
-        # Get the number of nodes from the state-by-node TPM.
-        N = tpm.shape[-1]
-        if tpm.ndim == 2:
-            if not (
-                (tpm.shape[0] == 2 ** N and tpm.shape[1] == N)
-                or (tpm.shape[0] == tpm.shape[1])
-            ):
-                raise ValueError(
-                    "Invalid shape for 2-D TPM: {}\nFor a state-by-node TPM, "
-                    "there must be "
-                    "2^N rows and N columns, where N is the "
-                    "number of nodes. State-by-state TPM must be square. "
-                    "{}".format(tpm.shape, see_tpm_docs)
-                )
-            if tpm.shape[0] == tpm.shape[1] and check_independence:
-                self.conditionally_independent()
-        elif tpm.ndim == (N + 1):
-            if tpm.shape != tuple([2] * N + [N]):
-                raise ValueError(
-                    "Invalid shape for multidimensional state-by-node TPM: {}\n"
-                    "The shape should be {} for {} nodes. {}".format(
-                        tpm.shape, ([2] * N) + [N], N, see_tpm_docs
-                    )
-                )
-        else:
-            raise ValueError(
-                "Invalid TPM: Must be either 2-dimensional or multidimensional. "
-                "{}".format(see_tpm_docs)
-            )
-        return True
-
-    def _validate_probabilities(self):
-        """Check that the probabilities in a TPM are valid."""
-        if (self._tpm < 0.0).any() or (self._tpm > 1.0).any():
-            raise ValueError(
-                "Invalid TPM: probabilities must be in the interval [0, 1]."
-            )
-        if self.is_state_by_state() and np.any(np.sum(self._tpm, axis=1) != 1.0):
-            raise ValueError("Invalid TPM: probabilities must sum to 1.")
-        return True
-
-    def validate(self, check_independence=True):
-        """Validate this TPM."""
-        return self._validate_probabilities() and self._validate_shape(
-            check_independence
-        )
-
-    def to_multidimensional_state_by_node(self):
-        """Return the current TPM re-represented in multidimensional
-        state-by-node form.
-
-        See the PyPhi documentation on :ref:`tpm-conventions` for more
-        information.
-
-        Returns:
-            np.ndarray: The TPM in multidimensional state-by-node format.
-        """
-        if self.is_state_by_state():
-            tpm = convert.state_by_state2state_by_node(self._tpm)
-        else:
-            tpm = convert.to_multidimensional(self._tpm)
-
-        return tpm
-
-    def squeeze(self, **kwargs):
-        """Remove axes of length one from the TPM."""
-        return type(self)(self._tpm.squeeze(**kwargs), validate=False)
 
     def __eq__(self, o: object):
         """Return whether this TPM equals the other object.
@@ -344,8 +477,8 @@ class ExplicitTPM(TPM):
         """
         return not self.__eq__(o)
 
-    def __mul__(self, o):
-        return type(self)(self._tpm * o._tpm, validate=False)
+    def __str__(self):
+        return self.__repr__()
 
     def __repr__(self):
         return "ExplicitTPM({})".format(self._tpm)

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -51,7 +51,7 @@ class ProxyMetaclass(type):
             "__rlshift__", "__rrshift__", "__rshift__",
             "__ior__", "__or__", "__ror__",
             "__xor__", "__ixor__", "__rxor__",
-            # __eq__ and __ne__ are explicitly implemented
+            "__eq__", "__ne__",
             "__ge__", "__gt__", "__lt__", "__le__",
             "__deepcopy__",
             # 3-ary
@@ -461,22 +461,6 @@ class ExplicitTPM(Wrapper):
         if isinstance(item, type(self._tpm)):
             item = type(self)(item, validate=False)
         return item
-
-    def __eq__(self, o: object):
-        """Return whether this TPM equals the other object.
-
-        Two TPMs are equal if they are instances of the ExplicitTPM class
-        and their numpy arrays are equal.
-        """
-        return isinstance(o, ExplicitTPM) and np.array_equal(self._tpm, o._tpm)
-
-    def __ne__(self, o: object):
-        """Return whether this TPM is different from the other object.
-
-        Two TPMs are equal if they are instances of the ExplicitTPM class
-        and their numpy arrays are equal. Otherwise they are different.
-        """
-        return not self.__eq__(o)
 
     def __str__(self):
         return self.__repr__()

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -110,6 +110,10 @@ class ProxyMetaclass(type):
 
 class Wrapper(metaclass=ProxyMetaclass):
     """Proxy to the array inside PyPhi's custom TPM class.
+
+    This is also where overloading of non-magic methods (e.g. tpm.sum(),
+    tpm.squeeze()) happens, providing a single interface to support, among other
+    things, proper type semantics for TPM operations.
     """
 
     __wraps__  = None

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -14,247 +14,17 @@ from . import config, convert, exceptions
 from .utils import all_states, np_hash, np_immutable
 from .constants import OFF, ON
 
-class ProxyMetaclass(type):
-    """A metaclass to create wrappers for the TPM array's special attributes.
 
-    The CPython interpreter resolves double-underscore attributes (e.g., the
-    method definitions of mathematical operators) by looking up in the class'
-    static methods, not in the instance methods. This makes it impossible to
-    intercept calls to them when an instance's __getattr__() is implicitly
-    invoked, which in turn means there are only two options to wrap the special
-    methods of the array inside our custom objects (e.g., to perform
-    arithmetic operations with the TPM while also casting the result to our
-    custom class type):
+class TPM:
+    """A transition probability matrix."""
 
-    - Manually overload all the necessary methods.
-    - Use this metaclass to automatically introspect the underlying array
-      methods and overload them in our custom TPM class definition.
-    """
-    def __init__(cls, type_name, bases, dct):
-
-        # Casting semantics: values belonging to our custom TPM class should
-        # remain closed under the following methods:
-        __closures__ = {
-            # 1-ary
-            "__abs__", "__copy__", "__invert__", "__neg__", "__pos__",
-            # 2-ary
-            "__add__", "__iadd__", "__radd__",
-            "__sub__", "__isub__", "__rsub__",
-            "__mul__", "__imul__", "__rmul__",
-            "__matmul__", "__imatmul__", "__rmatmul__",
-            "__truediv__", "__itruediv__", "__rtruediv__",
-            "__floordiv__", "__ifloordiv__", "__rfloordiv__",
-            "__mod__", "__imod__", "__rmod__",
-            "__and__", "__iand__", "__rand__",
-            "__lshift__", "__ilshift__", "__irshift__",
-            "__rlshift__", "__rrshift__", "__rshift__",
-            "__ior__", "__or__", "__ror__",
-            "__xor__", "__ixor__", "__rxor__",
-            # __eq__ and __ne__ are explicitly overloaded
-            "__ge__", "__gt__", "__lt__", "__le__",
-            "__deepcopy__",
-            # 3-ary
-            "__pow__", "__ipow__", "__rpow__",
-            # 2-ary, 2-valued
-            "__divmod__", "__rdivmod__"
-        }
-
-        def make_proxy(name):
-            """Returns a function that acts as a proxy for the given method name.
-
-            Args:
-                name (str): The name of the method to introspect in self._tpm.
-
-            Returns:
-                function: The wrapping function.
-            """
-            def proxy(self):
-                attribute = getattr(self._tpm, name)
-
-                if not name in __closures__:
-                    return attribute
-
-                def overriding_attribute(*args):
-                    # If second operand is a custom TPM, use its array instead.
-                    if args and isinstance(args[0], type(self)):
-                        args = list(args)
-                        args[0] = args[0]._tpm
-                        args = tuple(args)
-
-                    # Evaluate n-ary operator with self and rest of operands.
-                    result = attribute(*args)
-
-                    # Cast result to our custom TPM class.
-                    if isinstance(result, tuple):
-                        # Multivalued "functions" result in a tuple, e.g., the
-                        # 2-tuple (quotients, remainders) from __divmod__
-                        return (type(self)(r, validate=False) for r in result)
-
-                    return type(self)(result, validate=False)
-
-                return overriding_attribute
-
-            return proxy
-
-        type.__init__(cls, type_name, bases, dct)
-
-        if cls.__wraps__:
-            ignore = cls.__ignore__
-            # Go through all the attribute strings in the wrapped array type.
-            for name in dir(cls.__wraps__):
-                # Filter special attributes. The rest will be handled by Wrapper.
-                if name.startswith("__") and name not in ignore and name not in dct:
-                    # Create proxy function for `name` and bind it to future
-                    # instances of cls.
-                    setattr(cls, name, property(make_proxy(name)))
-
-class Wrapper(metaclass=ProxyMetaclass):
-    """Proxy to the array inside PyPhi's custom TPM class.
-
-    This is also where overloading of non-magic methods (e.g. tpm.sum(),
-    tpm.squeeze()) happens, providing a single interface to support, among other
-    things, proper type semantics for TPM operations.
-    """
-
-    __wraps__  = None
-    __ignore__ = {"class", "mro", "new", "init", "setattr", "getattr", "getattribute"}
-    __ignore__ = frozenset(f"__{i}__" for i in __ignore__)
-
-    def __init__(self, tpm):
-        if self.__wraps__ is None:
-            raise TypeError("Base class Wrapper may not be instantiated.")
-        if not isinstance(tpm, self.__wraps__):
-            raise ValueError(f"Wrapped object must be of type {self.__wraps__}")
-
-
-class ExplicitTPM(Wrapper):
-    """An explicit network TPM in multidimensional form."""
-
-    __wraps__ = np.ndarray
-
-    # Casting semantics: values belonging to our custom TPM class should
-    # remain closed under the following methods:
-    __closures__ =  {
-        "argpartition", "astype", "byteswap", "choose", "clip", "compress",
-        "conj", "conjugate", "copy", "cumprod", "cumsum", "diagonal", "dot",
-        "fill", "flatten", "getfield", "item", "itemset", "max", "mean", "min",
-        "newbyteorder", "partition", "prod", "ptp", "put", "ravel", "repeat",
-        "reshape", "resize", "round", "setfield", "sort", "squeeze", "std",
-        "sum", "swapaxes", "take", "transpose", "var", "view"
-    }
-    # TODO: data, real, imag return arrays that should be casted, however they
-    # are not callable.
-
-    # Proxy access to regular attributes of the wrapped array.
-    def __getattr__(self, name):
-        # Fix error with serialization. TODO: Implement dumps(), tobytes()?
-        if "_tpm" not in vars(self):
-            raise AttributeError
-
-        attribute = getattr(self._tpm, name)
-
-        if name not in self.__closures__:
-            return attribute
-
-        def overriding_method(*args, **kwargs):
-            # If second operand is a custom TPM, use its array instead.
-            if args and isinstance(args[0], type(self)):
-                args = list(args)
-                args[0] = args[0]._tpm
-                args = tuple(args)
-
-            result = attribute(*args, **kwargs)
-
-            # Test type of result. Reducing operations (e.g. sum(), max())
-            # return a scalar unless performed along an axis in a
-            # multidimensional array. Similarly, dot() may not return a scalar
-            # in general, because it is implemented in a polymorphic way.
-            if isinstance(result, self.__wraps__):
-                return type(self)(result, validate=False)
-
-            return result
-
-        # TODO search and replace return type.
-        overriding_method.__doc__ = attribute.__doc__
-
-        return overriding_method
-
-    def __init__(self, tpm, validate=True):
-        super().__init__(tpm)
-        self._tpm = np.array(tpm)
-
-        if validate:
-            self.validate(check_independence=config.VALIDATE_CONDITIONAL_INDEPENDENCE)
-            self._tpm = self.to_multidimensional_state_by_node()
-
-        self._tpm = np_immutable(self._tpm)
-        self._hash = np_hash(self._tpm)
+    def __init__(self):
+        raise NotImplementedError
 
     @property
     def tpm(self):
         """Return the underlying `tpm` object."""
         return self._tpm
-
-    def validate(self, check_independence=True):
-        """Validate this TPM."""
-        return self._validate_probabilities() and self._validate_shape(
-            check_independence
-        )
-
-    def _validate_probabilities(self):
-        """Check that the probabilities in a TPM are valid."""
-        if (self._tpm < 0.0).any() or (self._tpm > 1.0).any():
-            raise ValueError(
-                "Invalid TPM: probabilities must be in the interval [0, 1]."
-            )
-        if self.is_state_by_state() and np.any(np.sum(self._tpm, axis=1) != 1.0):
-            raise ValueError("Invalid TPM: probabilities must sum to 1.")
-        return True
-
-    def _validate_shape(self, check_independence=True):
-        """Validate this TPM's shape.
-
-        The TPM can be in
-
-            * 2-dimensional state-by-state form,
-            * 2-dimensional state-by-node form, or
-            * multidimensional state-by-node form.
-        """
-        see_tpm_docs = (
-            "See the documentation on TPM conventions and the `pyphi.Network` "
-            "object for more information on TPM forms."
-        )
-        tpm = self._tpm
-        # Get the number of nodes from the state-by-node TPM.
-        N = tpm.shape[-1]
-        if tpm.ndim == 2:
-            if not (
-                (tpm.shape[0] == 2 ** N and tpm.shape[1] == N)
-                or (tpm.shape[0] == tpm.shape[1])
-            ):
-                raise ValueError(
-                    "Invalid shape for 2-D TPM: {}\nFor a state-by-node TPM, "
-                    "there must be "
-                    "2^N rows and N columns, where N is the "
-                    "number of nodes. State-by-state TPM must be square. "
-                    "{}".format(tpm.shape, see_tpm_docs)
-                )
-            if tpm.shape[0] == tpm.shape[1] and check_independence:
-                self.conditionally_independent()
-        elif tpm.ndim == (N + 1):
-            if tpm.shape != tuple([2] * N + [N]):
-                raise ValueError(
-                    "Invalid shape for multidimensional state-by-node TPM: {}\n"
-                    "The shape should be {} for {} nodes. {}".format(
-                        tpm.shape, ([2] * N) + [N], N, see_tpm_docs
-                    )
-                )
-        else:
-            raise ValueError(
-                "Invalid TPM: Must be either 2-dimensional or multidimensional. "
-                "{}".format(see_tpm_docs)
-            )
-        return True
 
     def conditionally_independent(self):
         """Validate that the TPM is conditionally independent."""
@@ -276,22 +46,9 @@ class ExplicitTPM(Wrapper):
             )
         return True
 
-    def to_multidimensional_state_by_node(self):
-        """Return the current TPM re-represented in multidimensional
-        state-by-node form.
-
-        See the PyPhi documentation on :ref:`tpm-conventions` for more
-        information.
-
-        Returns:
-            np.ndarray: The TPM in multidimensional state-by-node format.
-        """
-        if self.is_state_by_state():
-            tpm = convert.state_by_state2state_by_node(self._tpm)
-        else:
-            tpm = convert.to_multidimensional(self._tpm)
-
-        return tpm
+    def validate(self):
+        """Ensure the tpm is well-formed."""
+        raise NotImplementedError
 
     def condition_tpm(self, fixed_nodes, state):
         """Return a TPM conditioned on the given fixed node indices, whose
@@ -444,11 +201,126 @@ class ExplicitTPM(Wrapper):
         for state in all_states(tpm.shape[-1]):
             print(f"{state}: {tpm[state]}")
 
+    def __getattr__(self, name):
+        if "_tpm" not in vars(self):
+            raise AttributeError
+
+        attribute = getattr(self._tpm, name)
+
+        if name in {"squeeze", "__mul__"}:
+            overriding_method = lambda *args, **kwargs: type(self)(
+                attribute(*args, **kwargs),
+                validate=False
+            )
+            overriding_method.__doc__ = attribute.__doc__
+
+            return overriding_method
+
+        return attribute
+
     def __getitem__(self, i):
         item = self._tpm[i]
         if isinstance(item, type(self._tpm)):
             item = type(self)(item, validate=False)
         return item
+
+    def __repr__(self):
+        raise NotImplementedError
+
+    def __str__(self):
+        return self.__repr__()
+
+
+class ExplicitTPM(TPM):
+    """An explicit network TPM in multidimensional form."""
+
+    def __init__(self, tpm, validate=True):
+        self._tpm = np.array(tpm)
+
+        if validate:
+            self.validate(check_independence=config.VALIDATE_CONDITIONAL_INDEPENDENCE)
+            self._tpm = self.to_multidimensional_state_by_node()
+
+        self._tpm = np_immutable(self._tpm)
+        self._hash = np_hash(self._tpm)
+
+    def _validate_shape(self, check_independence=True):
+        """Validate this TPM's shape.
+
+        The TPM can be in
+
+            * 2-dimensional state-by-state form,
+            * 2-dimensional state-by-node form, or
+            * multidimensional state-by-node form.
+        """
+        see_tpm_docs = (
+            "See the documentation on TPM conventions and the `pyphi.Network` "
+            "object for more information on TPM forms."
+        )
+        tpm = self._tpm
+        # Get the number of nodes from the state-by-node TPM.
+        N = tpm.shape[-1]
+        if tpm.ndim == 2:
+            if not (
+                (tpm.shape[0] == 2 ** N and tpm.shape[1] == N)
+                or (tpm.shape[0] == tpm.shape[1])
+            ):
+                raise ValueError(
+                    "Invalid shape for 2-D TPM: {}\nFor a state-by-node TPM, "
+                    "there must be "
+                    "2^N rows and N columns, where N is the "
+                    "number of nodes. State-by-state TPM must be square. "
+                    "{}".format(tpm.shape, see_tpm_docs)
+                )
+            if tpm.shape[0] == tpm.shape[1] and check_independence:
+                self.conditionally_independent()
+        elif tpm.ndim == (N + 1):
+            if tpm.shape != tuple([2] * N + [N]):
+                raise ValueError(
+                    "Invalid shape for multidimensional state-by-node TPM: {}\n"
+                    "The shape should be {} for {} nodes. {}".format(
+                        tpm.shape, ([2] * N) + [N], N, see_tpm_docs
+                    )
+                )
+        else:
+            raise ValueError(
+                "Invalid TPM: Must be either 2-dimensional or multidimensional. "
+                "{}".format(see_tpm_docs)
+            )
+        return True
+
+    def _validate_probabilities(self):
+        """Check that the probabilities in a TPM are valid."""
+        if (self._tpm < 0.0).any() or (self._tpm > 1.0).any():
+            raise ValueError(
+                "Invalid TPM: probabilities must be in the interval [0, 1]."
+            )
+        if self.is_state_by_state() and np.any(np.sum(self._tpm, axis=1) != 1.0):
+            raise ValueError("Invalid TPM: probabilities must sum to 1.")
+        return True
+
+    def validate(self, check_independence=True):
+        """Validate this TPM."""
+        return self._validate_probabilities() and self._validate_shape(
+            check_independence
+        )
+
+    def to_multidimensional_state_by_node(self):
+        """Return the current TPM re-represented in multidimensional
+        state-by-node form.
+
+        See the PyPhi documentation on :ref:`tpm-conventions` for more
+        information.
+
+        Returns:
+            np.ndarray: The TPM in multidimensional state-by-node format.
+        """
+        if self.is_state_by_state():
+            tpm = convert.state_by_state2state_by_node(self._tpm)
+        else:
+            tpm = convert.to_multidimensional(self._tpm)
+
+        return tpm
 
     def __eq__(self, o: object):
         """Return whether this TPM equals the other object.
@@ -466,14 +338,15 @@ class ExplicitTPM(Wrapper):
         """
         return not self.__eq__(o)
 
-    def __str__(self):
-        return self.__repr__()
+    def __mul__(self, o):
+        return self.__getattr__("__mul__")(o)
 
     def __repr__(self):
-        return f"ExplicitTPM({self._tpm})"
+        return "ExplicitTPM({})".format(self._tpm)
 
     def __hash__(self):
         return self._hash
+
 
 def reconstitute_tpm(subsystem):
     """Reconstitute the TPM of a subsystem using the individual node TPMs."""

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -35,7 +35,7 @@ class ProxyMetaclass(type):
 
         # Casting semantics: values belonging to our custom TPM class should
         # remain closed under the following methods:
-        __closures__ = frozenset{
+        __closures__ = frozenset({
             # 1-ary
             "__abs__", "__copy__", "__invert__", "__neg__", "__pos__",
             # 2-ary
@@ -58,7 +58,7 @@ class ProxyMetaclass(type):
             "__pow__", "__ipow__", "__rpow__",
             # 2-ary, 2-valued
             "__divmod__", "__rdivmod__"
-        }
+        })
 
         def make_proxy(name):
             """Returns a function that acts as a proxy for the given method name.
@@ -132,14 +132,14 @@ class ExplicitTPM(Wrapper):
 
     # Casting semantics: values belonging to our custom TPM class should
     # remain closed under the following methods:
-    __closures__ =  frozenset{
+    __closures__ =  frozenset({
         "argpartition", "astype", "byteswap", "choose", "clip", "compress",
         "conj", "conjugate", "copy", "cumprod", "cumsum", "diagonal", "dot",
         "fill", "flatten", "getfield", "item", "itemset", "max", "mean", "min",
         "newbyteorder", "partition", "prod", "ptp", "put", "ravel", "repeat",
         "reshape", "resize", "round", "setfield", "sort", "squeeze", "std",
         "sum", "swapaxes", "take", "transpose", "var", "view"
-    }
+    })
 
     # Proxy access to regular attributes of the wrapped array.
     def __getattr__(self, name):

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -34,7 +34,7 @@ class ProxyMetaclass(type):
 
         # Casting semantics: values belonging to our custom TPM class should
         # remain closed under the following methods:
-        __closures__ = {
+        __closures__ = frozenset({
             # 1-ary
             "__abs__", "__copy__", "__invert__", "__neg__", "__pos__",
             # 2-ary
@@ -57,7 +57,7 @@ class ProxyMetaclass(type):
             "__pow__", "__ipow__", "__rpow__",
             # 2-ary, 2-valued
             "__divmod__", "__rdivmod__"
-        }
+        })
 
         def make_proxy(name):
             """Returns a function that acts as a proxy for the given method name.
@@ -130,14 +130,14 @@ class ExplicitTPM(Wrapper):
 
     # Casting semantics: values belonging to our custom TPM class should
     # remain closed under the following methods:
-    __closures__ =  {
+    __closures__ =  frozenset({
         "argpartition", "astype", "byteswap", "choose", "clip", "compress",
         "conj", "conjugate", "copy", "cumprod", "cumsum", "diagonal", "dot",
         "fill", "flatten", "getfield", "item", "itemset", "max", "mean", "min",
         "newbyteorder", "partition", "prod", "ptp", "put", "ravel", "repeat",
         "reshape", "resize", "round", "setfield", "sort", "squeeze", "std",
         "sum", "swapaxes", "take", "transpose", "var", "view"
-    }
+    })
     # TODO: data, real, imag return arrays that should be casted, however they
     # are not callable.
 

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -110,10 +110,6 @@ class ProxyMetaclass(type):
 
 class Wrapper(metaclass=ProxyMetaclass):
     """Proxy to the array inside PyPhi's custom TPM class.
-
-    This is also where overloading of non-magic methods (e.g. tpm.sum(),
-    tpm.squeeze()) happens, providing a single interface to support, among other
-    things, proper type semantics for TPM operations.
     """
 
     __wraps__  = None

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -34,7 +34,7 @@ class ProxyMetaclass(type):
 
         # Casting semantics: values belonging to our custom TPM class should
         # remain closed under the following methods:
-        __closures__ = frozenset({
+        __closures__ = {
             # 1-ary
             "__abs__", "__copy__", "__invert__", "__neg__", "__pos__",
             # 2-ary
@@ -57,7 +57,7 @@ class ProxyMetaclass(type):
             "__pow__", "__ipow__", "__rpow__",
             # 2-ary, 2-valued
             "__divmod__", "__rdivmod__"
-        })
+        }
 
         def make_proxy(name):
             """Returns a function that acts as a proxy for the given method name.
@@ -130,14 +130,14 @@ class ExplicitTPM(Wrapper):
 
     # Casting semantics: values belonging to our custom TPM class should
     # remain closed under the following methods:
-    __closures__ =  frozenset({
+    __closures__ =  {
         "argpartition", "astype", "byteswap", "choose", "clip", "compress",
         "conj", "conjugate", "copy", "cumprod", "cumsum", "diagonal", "dot",
         "fill", "flatten", "getfield", "item", "itemset", "max", "mean", "min",
         "newbyteorder", "partition", "prod", "ptp", "put", "ravel", "repeat",
         "reshape", "resize", "round", "setfield", "sort", "squeeze", "std",
         "sum", "swapaxes", "take", "transpose", "var", "view"
-    })
+    }
     # TODO: data, real, imag return arrays that should be casted, however they
     # are not callable.
 

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -368,12 +368,12 @@ class ExplicitTPM(Wrapper):
         Examples:
             >>> from pyphi import examples
             >>> # Get the TPM for nodes only 1 and 2, conditioned on node 0 = OFF
-            >>> subtpm(examples.grid3_network().tpm.tpm, (0,), (0,))
-            ExplicitTPM(array([[[[0.02931223, 0.04742587],
-                                 [0.07585818, 0.88079708]],
+            >>> examples.grid3_network().tpm.subtpm((0,), (0,))
+            ExplicitTPM([[[[0.02931223 0.04742587]
+               [0.07585818 0.88079708]]
             <BLANKLINE>
-                                [[0.81757448, 0.11920292],
-                                 [0.92414182, 0.95257413]]]]))
+              [[0.81757448 0.11920292]
+               [0.92414182 0.95257413]]]])
         """
         N = self._tpm.shape[-1]
         free_nodes = sorted(set(range(N)) - set(fixed_nodes))

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -462,6 +462,14 @@ class ExplicitTPM(Wrapper):
             item = type(self)(item, validate=False)
         return item
 
+    def array_equal(self, o: object):
+        """Return whether this TPM equals the other object.
+
+        Two TPMs are equal if they are instances of the ExplicitTPM class
+        and their numpy arrays are equal.
+        """
+        return isinstance(o, type(self)) and np.array_equal(self._tpm, o._tpm)
+
     def __str__(self):
         return self.__repr__()
 

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -204,19 +204,7 @@ class TPM:
     def __getattr__(self, name):
         if "_tpm" not in vars(self):
             raise AttributeError
-
-        attribute = getattr(self._tpm, name)
-
-        if name in {"squeeze", "__mul__"}:
-            overriding_method = lambda *args, **kwargs: type(self)(
-                attribute(*args, **kwargs),
-                validate=False
-            )
-            overriding_method.__doc__ = attribute.__doc__
-
-            return overriding_method
-
-        return attribute
+        return getattr(self._tpm, name)
 
     def __getitem__(self, i):
         item = self._tpm[i]
@@ -322,6 +310,10 @@ class ExplicitTPM(TPM):
 
         return tpm
 
+    def squeeze(self, **kwargs):
+        """Remove axes of length one from the TPM."""
+        return type(self)(self._tpm.squeeze(**kwargs), validate=False)
+
     def __eq__(self, o: object):
         """Return whether this TPM equals the other object.
 
@@ -339,7 +331,7 @@ class ExplicitTPM(TPM):
         return not self.__eq__(o)
 
     def __mul__(self, o):
-        return self.__getattr__("__mul__")(o)
+        return type(self)(self._tpm * o._tpm, validate=False)
 
     def __repr__(self):
         return "ExplicitTPM({})".format(self._tpm)

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -377,7 +377,8 @@ class ExplicitTPM(Wrapper):
         """
         N = self._tpm.shape[-1]
         free_nodes = sorted(set(range(N)) - set(fixed_nodes))
-        conditioned = self.condition_tpm(fixed_nodes, state)
+        condition = FrozenMap(zip(fixed_nodes, state))
+        conditioned = self.condition_tpm(condition)
         # TODO test indicing behavior on xr.DataArray
         return conditioned[..., free_nodes]
 

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -117,11 +117,11 @@ class Wrapper(metaclass=ProxyMetaclass):
     __ignore__ = {"class", "mro", "new", "init", "setattr", "getattr", "getattribute"}
     __ignore__ = frozenset(f"__{i}__" for i in __ignore__)
 
-    def __init__(self, tpm):
+    def __init__(self):
         if self.__wraps__ is None:
             raise TypeError("Base class Wrapper may not be instantiated.")
 
-        if not isinstance(tpm, self.__wraps__):
+        if not isinstance(self._tpm, self.__wraps__):
             raise ValueError(f"Wrapped object must be of type {self.__wraps__}")
 
 
@@ -178,8 +178,8 @@ class ExplicitTPM(Wrapper):
         return overriding_method
 
     def __init__(self, tpm, validate=True):
-        super().__init__(tpm)
         self._tpm = np.array(tpm)
+        super().__init__()
 
         if validate:
             self.validate(check_independence=config.VALIDATE_CONDITIONAL_INDEPENDENCE)

--- a/test/test_actual.py
+++ b/test/test_actual.py
@@ -128,8 +128,8 @@ def test_background_noised():
     transition = actual.Transition(
         network, state, state, (0,), (0,), noise_background=True
     )
-    assert transition.cause_system.tpm == network.tpm
-    assert transition.effect_system.tpm == network.tpm
+    assert transition.cause_system.tpm.array_equal(network.tpm)
+    assert transition.effect_system.tpm.array_equal(network.tpm)
 
 
 @pytest.fixture

--- a/test/test_actual.py
+++ b/test/test_actual.py
@@ -128,8 +128,8 @@ def test_background_noised():
     transition = actual.Transition(
         network, state, state, (0,), (0,), noise_background=True
     )
-    assert np.array_equal(transition.cause_system.tpm, network.tpm)
-    assert np.array_equal(transition.effect_system.tpm, network.tpm)
+    assert transition.cause_system.tpm == network.tpm
+    assert transition.effect_system.tpm == network.tpm
 
 
 @pytest.fixture

--- a/test/test_macro.py
+++ b/test/test_macro.py
@@ -359,7 +359,7 @@ def test_remove_singleton_dimensions():
 
 def test_pack_attrs(s):
     attrs = macro.SystemAttrs.pack(s)
-    assert np.array_equal(attrs.tpm, s.tpm)
+    assert attrs.tpm == s.tpm
     assert np.array_equal(attrs.cm, s.cm)
     assert attrs.node_indices == s.node_indices
     assert attrs.state == s.state

--- a/test/test_macro.py
+++ b/test/test_macro.py
@@ -294,10 +294,10 @@ def test_rebuild_system_tpm(s):
         validate=False
     )
     # fmt: on
-    assert macro.rebuild_system_tpm(node_tpms) == answer
+    assert macro.rebuild_system_tpm(node_tpms).array_equal(answer)
 
     node_tpms = [node.tpm_on for node in s.nodes]
-    assert macro.rebuild_system_tpm(node_tpms) == s.tpm
+    assert macro.rebuild_system_tpm(node_tpms).array_equal(s.tpm)
 
 
 def test_remove_singleton_dimensions():
@@ -312,7 +312,7 @@ def test_remove_singleton_dimensions():
     )
     # fmt: on
     assert tpm.tpm_indices() == (0,)
-    assert macro.remove_singleton_dimensions(tpm) == tpm
+    assert macro.remove_singleton_dimensions(tpm).array_equal(tpm)
 
     # fmt: off
     tpm = ExplicitTPM(
@@ -331,7 +331,7 @@ def test_remove_singleton_dimensions():
     )
     # fmt: on
     assert tpm.tpm_indices() == (1,)
-    assert macro.remove_singleton_dimensions(tpm) == answer
+    assert macro.remove_singleton_dimensions(tpm).array_equal(answer)
 
     # fmt: off
     tpm = ExplicitTPM(
@@ -354,12 +354,12 @@ def test_remove_singleton_dimensions():
     )
     # fmt: on
     assert tpm.tpm_indices() == (0, 2)
-    assert macro.remove_singleton_dimensions(tpm) == answer
+    assert macro.remove_singleton_dimensions(tpm).array_equal(answer)
 
 
 def test_pack_attrs(s):
     attrs = macro.SystemAttrs.pack(s)
-    assert attrs.tpm == s.tpm
+    assert attrs.tpm.array_equal(s.tpm)
     assert np.array_equal(attrs.cm, s.cm)
     assert attrs.node_indices == s.node_indices
     assert attrs.state == s.state
@@ -375,7 +375,7 @@ def test_apply_attrs(s):
     target = SomeSystem()
 
     attrs.apply(target)
-    assert target.tpm == s.tpm
+    assert target.tpm.array_equal(s.tpm)
     assert np.array_equal(target.cm, s.cm)
     assert target.node_indices == s.node_indices
     assert target.state == s.state

--- a/test/test_macro_blackbox.py
+++ b/test/test_macro_blackbox.py
@@ -347,7 +347,7 @@ def test_degenerate(degenerate):
         validate=False
     )
     # fmt: on
-    assert degenerate.tpm == answer
+    assert degenerate.tpm.array_equal(answer)
     # fmt: off
     answer = np.array([
         [0, 1],

--- a/test/test_macro_blackbox.py
+++ b/test/test_macro_blackbox.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
 
-from pyphi import Network, compute, config, convert, macro, models, utils
+from pyphi import (
+    Network, compute, config, convert, ExplicitTPM, macro, models, utils
+)
 
 
 # TODO: move these to examples.py
@@ -335,14 +337,17 @@ def test_coarsegrain_spatial_degenerate():
 @pytest.mark.slow
 def test_degenerate(degenerate):
     # fmt: off
-    answer = convert.to_multidimensional(np.array([
-        [0, 0],
-        [0, 1],
-        [1, 0],
-        [1, 1],
-    ]))
+    answer = ExplicitTPM(
+        np.array(
+            [[0, 0],
+             [0, 1],
+             [1, 0],
+             [1, 1]]
+        ),
+        validate=False
+    )
     # fmt: on
-    assert np.array_equal(degenerate.tpm, answer)
+    assert degenerate.tpm == answer
     # fmt: off
     answer = np.array([
         [0, 1],

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -31,7 +31,7 @@ def test_node_init_tpm(s):
     answer = [ExplicitTPM(tpm, validate=False) for tpm in answer]
     # fmt: on
     for node in s.nodes:
-        assert node.tpm == answer[node.index]
+        assert node.tpm.array_equal(answer[node.index])
 
 
 def test_node_init_inputs(s):
@@ -79,7 +79,7 @@ def test_expand_tpm():
         validate=False
     )
     # fmt: on
-    assert expand_node_tpm(tpm) == answer
+    assert expand_node_tpm(tpm).array_equal(answer)
 
 
 def test_generate_nodes(s):
@@ -96,7 +96,7 @@ def test_generate_nodes(s):
         validate=False
     )
     # fmt: on
-    assert nodes[0].tpm == node0_tpm
+    assert nodes[0].tpm.array_equal(node0_tpm)
     assert nodes[0].inputs == set([1, 2])
     assert nodes[0].outputs == set([2])
     assert nodes[0].label == "A"
@@ -110,7 +110,7 @@ def test_generate_nodes(s):
         validate=False
     )
     # fmt: on
-    assert nodes[1].tpm == node1_tpm
+    assert nodes[1].tpm.array_equal(node1_tpm)
     assert nodes[1].inputs == set([2])
     assert nodes[1].outputs == set([0, 2])
     assert nodes[1].label == "B"
@@ -126,7 +126,7 @@ def test_generate_nodes(s):
         validate=False
     )
     # fmt: on
-    assert nodes[2].tpm == node2_tpm
+    assert nodes[2].tpm.array_equal(node2_tpm)
     assert nodes[2].inputs == set([0, 1])
     assert nodes[2].outputs == set([0, 1])
     assert nodes[2].label == "C"

--- a/test/test_tpm.py
+++ b/test/test_tpm.py
@@ -37,7 +37,7 @@ def test_expand_tpm():
         validate=False
     )
     # fmt: on
-    assert tpm.expand_tpm() == answer
+    assert tpm.expand_tpm().array_equal(answer)
 
 
 def test_marginalize_out(s):
@@ -54,7 +54,7 @@ def test_marginalize_out(s):
     )
 
     # fmt: on
-    assert marginalized_distribution == answer
+    assert marginalized_distribution.array_equal(answer)
 
     marginalized_distribution = s.tpm.marginalize_out([0, 1])
     # fmt: off
@@ -66,7 +66,7 @@ def test_marginalize_out(s):
         validate=False
     )
     # fmt: on
-    assert marginalized_distribution == answer
+    assert marginalized_distribution.array_equal(answer)
 
 
 def test_infer_cm(rule152):


### PR DESCRIPTION
Now that the current state of both branches is reasonably clean, and before (a) introducing xarray as the base array type and (b) before divergence increases, I would like to bring these changes (and conflicts) to the table and possibly merge.


```sh
feature/iit-4.0 $  py.test -k 'not test_relations' -W ignore::UserWarning
[...]
104 failed, 579 passed, 37 skipped, 27 deselected, 2 xfailed, 23 errors in 88.10s (0:01:28)
```

```sh
feature/tpm-class $  py.test -k 'not test_relations' -W ignore::UserWarning
[...]
103 failed, 580 passed, 37 skipped, 27 deselected, 2 xfailed, 23 errors in 75.63s (0:01:15)
```

[bfd62c9](https://github.com/wmayner/pyphi/commit/bfd62c99ad3f0ec5d0558596d24c8cd1010c9491) includes a workaround for the issue I experienced with parallel evaluation, reproducible using Matteo's example:

```python3
import pyphi

k = 4
n = 7

weights = pyphi.network_generator.weights.nearest_neighbor(n,.5,.5)
state = (0,)*n
network = pyphi.network_generator.build_network([pyphi.network_generator.ising.probability]*n,weights,temperature=1/k)
subsystems = [pyphi.Subsystem(network,state,nodes=nodes) for nodes in pyphi.utils.powerset(range(n),nonempty=True)]
sias = [pyphi.new_big_phi.sia(subsystem) for subsystem in subsystems]
```