### PR TITLE
Python 3.8 support

### DIFF
--- a/pyphi/models/mechanism.py
+++ b/pyphi/models/mechanism.py
@@ -5,7 +5,7 @@
 """Mechanism-level objects."""
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -26,8 +26,8 @@ from . import cmp, fmt
 @dataclass
 class StateSpecification:
     direction: Direction
-    purview: tuple[int]
-    state: tuple[tuple[int]]
+    purview: Tuple[int]
+    state: Tuple[Tuple[int]]
     intrinsic_information: float
     repertoire: ArrayLike
     unconstrained_repertoire: ArrayLike

--- a/pyphi/new_big_phi/__init__.py
+++ b/pyphi/new_big_phi/__init__.py
@@ -4,7 +4,7 @@ from copy import copy
 from dataclasses import dataclass
 from enum import Enum, auto, unique
 from textwrap import indent
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Tuple, Union
 
 from .. import Direction, Subsystem, compute, config, connectivity, utils
 from ..compute.network import reachable_subsystems
@@ -118,8 +118,8 @@ class SystemIrreducibilityAnalysis(cmp.Orderable):
     cause: Optional[RepertoireIrreducibilityAnalysis] = None
     effect: Optional[RepertoireIrreducibilityAnalysis] = None
     system_state: Optional[SystemStateSpecification] = None
-    current_state: Optional[tuple[int]] = None
-    node_indices: Optional[tuple[int]] = None
+    current_state: Optional[Tuple[int]] = None
+    node_indices: Optional[Tuple[int]] = None
     node_labels: Optional[NodeLabels] = None
     reasons: Optional[list] = None
 

--- a/pyphi/new_big_phi/min_max_horizontal.py
+++ b/pyphi/new_big_phi/min_max_horizontal.py
@@ -1,7 +1,7 @@
 # new_big_phi/min_max_horizontal.py
 
 from dataclasses import dataclass
-from typing import Generator, Iterable, Optional, Union
+from typing import Generator, Iterable, Optional, Tuple, Union
 
 from numpy.typing import ArrayLike
 
@@ -47,7 +47,7 @@ partition_schemes = PartitionSchemeRegistry()
 
 
 def system_partitions(
-    node_indices: tuple[int], node_labels: NodeLabels
+    node_indices: Tuple[int], node_labels: NodeLabels
 ) -> Generator[SystemPartition, None, None]:
     """Generate system partitions."""
     return partition_schemes[config.IIT_4_SYSTEM_PARTITION_TYPE](
@@ -72,9 +72,9 @@ class HorizontalSystemPartition(SystemPartition):
     """A 'horizontal' system partition."""
 
     direction: Direction
-    purview: tuple[int]
-    unpartitioned_mechanism: tuple[int]
-    partitioned_mechanism: tuple[int]
+    purview: Tuple[int]
+    unpartitioned_mechanism: Tuple[int]
+    partitioned_mechanism: Tuple[int]
     node_labels: Optional[NodeLabels] = None
 
     def normalization_factor(self):
@@ -243,11 +243,11 @@ class SystemIrreducibilityAnalysis(cmp.Orderable):
     phi: float
     normalized_phi: float
     partition: Union[Cut, SystemPartition]
-    maximal_purview: tuple[int]
+    maximal_purview: Tuple[int]
     repertoire: ArrayLike
     partitioned_repertoire: ArrayLike
-    system_state: Optional[tuple[int]] = None
-    node_indices: Optional[tuple[int]] = None
+    system_state: Optional[Tuple[int]] = None
+    node_indices: Optional[Tuple[int]] = None
     node_labels: Optional[NodeLabels] = None
     reasons: Optional[list] = None
 

--- a/pyphi/new_big_phi/min_max_horizontal.py
+++ b/pyphi/new_big_phi/min_max_horizontal.py
@@ -63,7 +63,7 @@ class SystemPartition:
 
     def evaluate(
         self, subsystem: Subsystem, system_state: SystemStateSpecification, **kwargs
-    ) -> tuple[float, ArrayLike, ArrayLike]:
+    ) -> Tuple[float, ArrayLike, ArrayLike]:
         raise NotImplementedError
 
 
@@ -82,7 +82,7 @@ class HorizontalSystemPartition(SystemPartition):
 
     def evaluate(
         self, subsystem: Subsystem, system_state: SystemStateSpecification, **kwargs
-    ) -> tuple[float, ArrayLike, ArrayLike]:
+    ) -> Tuple[float, ArrayLike, ArrayLike]:
         valid_distances = ["IIT_4.0_SMALL_PHI", "IIT_4.0_SMALL_PHI_NO_ABSOLUTE_VALUE"]
         if config.REPERTOIRE_DISTANCE not in valid_distances:
             raise ValueError(

--- a/pyphi/repertoire.py
+++ b/pyphi/repertoire.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # repertoire.py
 
-from typing import Callable
+from typing import Callable, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -35,9 +35,9 @@ def _directional_dispatch(cause_func: Callable, effect_func: Callable) -> Callab
 
 def forward_effect_probability(
     subsystem,
-    mechanism: tuple[int],
-    purview: tuple[int],
-    purview_state: tuple[int],
+    mechanism: Tuple[int],
+    purview: Tuple[int],
+    purview_state: Tuple[int],
     **kwargs
 ) -> float:
     return forward_effect_repertoire(subsystem, mechanism, purview, **kwargs).squeeze()[
@@ -46,16 +46,16 @@ def forward_effect_probability(
 
 
 def forward_effect_repertoire(
-    subsystem, mechanism: tuple[int], purview: tuple[int], **kwargs
+    subsystem, mechanism: Tuple[int], purview: Tuple[int], **kwargs
 ) -> ArrayLike:
     return subsystem.effect_repertoire(mechanism, purview, **kwargs)
 
 
 def forward_cause_probability(
     subsystem,
-    mechanism: tuple[int],
-    purview: tuple[int],
-    purview_state: tuple[int],
+    mechanism: Tuple[int],
+    purview: Tuple[int],
+    purview_state: Tuple[int],
     mechanism_state=None,
 ) -> float:
     if mechanism_state is None:
@@ -71,7 +71,7 @@ def forward_cause_probability(
 
 
 def forward_cause_repertoire(
-    subsystem, mechanism: tuple[int], purview: tuple[int], purview_state=None
+    subsystem, mechanism: Tuple[int], purview: Tuple[int], purview_state=None
 ) -> ArrayLike:
     mechanism_state = utils.state_of(mechanism, subsystem.state)
     if purview:
@@ -97,7 +97,7 @@ forward_repertoire = _directional_dispatch(
 
 
 def unconstrained_forward_effect_repertoire(
-    subsystem, mechanism: tuple[int], purview: tuple[int]
+    subsystem, mechanism: Tuple[int], purview: Tuple[int]
 ) -> ArrayLike:
     # Get the effect repertoire for each mechanism state.
     repertoires = np.stack(
@@ -114,7 +114,7 @@ def unconstrained_forward_effect_repertoire(
 
 
 def unconstrained_forward_cause_repertoire(
-    subsystem, mechanism: tuple[int], purview: tuple[int]
+    subsystem, mechanism: Tuple[int], purview: Tuple[int]
 ) -> ArrayLike:
     # See Eq. 32 in 4.0 paper.
     # Here, the roles of `m` and `z` in the equation are switched, so the

--- a/pyphi/subsystem.py
+++ b/pyphi/subsystem.py
@@ -407,7 +407,7 @@ class Subsystem:
     def _effect_repertoire(
         self,
         condition: FrozenMap[int, int],
-        purview: tuple[int],
+        purview: Tuple[int],
     ):
         # Preallocate the repertoire with the proper shape, so that
         # probabilities are broadcasted appropriately.
@@ -523,9 +523,9 @@ class Subsystem:
     def forward_probability(
         self,
         direction: Direction,
-        mechanism: tuple[int],
-        purview: tuple[int],
-        purview_state: tuple[int],
+        mechanism: Tuple[int],
+        purview: Tuple[int],
+        purview_state: Tuple[int],
         **kwargs,
     ) -> float:
         if direction == Direction.CAUSE:
@@ -540,9 +540,9 @@ class Subsystem:
 
     def forward_effect_probability(
         self,
-        mechanism: tuple[int],
-        purview: tuple[int],
-        purview_state: tuple[int],
+        mechanism: Tuple[int],
+        purview: Tuple[int],
+        purview_state: Tuple[int],
         **kwargs,
     ) -> float:
         return _repertoire.forward_effect_probability(
@@ -551,9 +551,9 @@ class Subsystem:
 
     def forward_cause_probability(
         self,
-        mechanism: tuple[int],
-        purview: tuple[int],
-        purview_state: tuple[int],
+        mechanism: Tuple[int],
+        purview: Tuple[int],
+        purview_state: Tuple[int],
         **kwargs,
     ) -> float:
         return _repertoire.forward_cause_probability(
@@ -561,7 +561,7 @@ class Subsystem:
         )
 
     def forward_repertoire(
-        self, direction: Direction, mechanism: tuple[int], purview: tuple[int], **kwargs
+        self, direction: Direction, mechanism: Tuple[int], purview: Tuple[int], **kwargs
     ) -> ArrayLike:
         if direction == Direction.CAUSE:
             return self.forward_cause_repertoire(mechanism, purview)
@@ -571,19 +571,19 @@ class Subsystem:
 
     @cache.method("_forward_repertoire_cache", Direction.CAUSE)
     def forward_cause_repertoire(
-        self, mechanism: tuple[int], purview: tuple[int]
+        self, mechanism: Tuple[int], purview: Tuple[int]
     ) -> ArrayLike:
         return _repertoire.forward_cause_repertoire(self, mechanism, purview)
 
     # NOTE: No caching is required here because the forward effect repertoire is
     # the same as the effect repertoire.
     def forward_effect_repertoire(
-        self, mechanism: tuple[int], purview: tuple[int], **kwargs
+        self, mechanism: Tuple[int], purview: Tuple[int], **kwargs
     ) -> ArrayLike:
         return _repertoire.forward_effect_repertoire(self, mechanism, purview, **kwargs)
 
     def unconstrained_forward_repertoire(
-        self, direction: Direction, mechanism: tuple[int], purview: tuple[int]
+        self, direction: Direction, mechanism: Tuple[int], purview: Tuple[int]
     ) -> ArrayLike:
         if direction == Direction.CAUSE:
             return self.unconstrained_forward_cause_repertoire(mechanism, purview)
@@ -593,7 +593,7 @@ class Subsystem:
 
     @cache.method("_unconstrained_forward_repertoire_cache", Direction.EFFECT)
     def unconstrained_forward_effect_repertoire(
-        self, mechanism: tuple[int], purview: tuple[int]
+        self, mechanism: Tuple[int], purview: Tuple[int]
     ) -> ArrayLike:
         return _repertoire.unconstrained_forward_effect_repertoire(
             self, mechanism, purview
@@ -601,7 +601,7 @@ class Subsystem:
 
     @cache.method("_unconstrained_forward_repertoire_cache", Direction.CAUSE)
     def unconstrained_forward_cause_repertoire(
-        self, mechanism: tuple[int], purview: tuple[int]
+        self, mechanism: Tuple[int], purview: Tuple[int]
     ) -> ArrayLike:
         return _repertoire.unconstrained_forward_cause_repertoire(
             self, mechanism, purview
@@ -948,8 +948,8 @@ class Subsystem:
     def intrinsic_information(
         self,
         direction: Direction,
-        mechanism: tuple[int],
-        purview: tuple[int],
+        mechanism: Tuple[int],
+        purview: Tuple[int],
         repertoire_distance: str = None,
         states: Iterable[Iterable[int]] = None,
     ):

--- a/pyphi/subsystem.py
+++ b/pyphi/subsystem.py
@@ -6,7 +6,7 @@
 
 import functools
 import logging
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import numpy as np
 from numpy.typing import ArrayLike

--- a/pyphi/tpm.py
+++ b/pyphi/tpm.py
@@ -7,7 +7,7 @@ Provides the TPM, ExplicitTPM, and ImplicitTPM classes.
 """
 
 from itertools import chain
-from typing import Mapping
+from typing import Mapping, Set
 
 import numpy as np
 
@@ -553,7 +553,7 @@ def reconstitute_tpm(subsystem):
 
 
 def _new_attribute(
-    name: str, closures: set[str], tpm: ExplicitTPM.__wraps__, cls=ExplicitTPM
+    name: str, closures: Set[str], tpm: ExplicitTPM.__wraps__, cls=ExplicitTPM
 ) -> object:
     """Helper function to return adequate proxy attributes for TPM arrays.
 

--- a/pyphi/utils.py
+++ b/pyphi/utils.py
@@ -12,6 +12,7 @@ import math
 import operator
 import os
 from itertools import chain, combinations, product
+from typing import Tuple
 
 import numpy as np
 from scipy.special import comb
@@ -22,8 +23,8 @@ from . import config
 
 # TODO(states) refactor
 def substate(
-    nodes: tuple[int], state: tuple[int], node_subset: tuple[int]
-) -> tuple[int]:
+    nodes: Tuple[int], state: Tuple[int], node_subset: Tuple[int]
+) -> Tuple[int]:
     return tuple(state[nodes.index(n)] for n in node_subset)
 
 
@@ -51,7 +52,7 @@ def all_states(n, big_endian=False):
             instead of little-endian order.
 
     Yields:
-        tuple[int]: The next state of an ``n``-element system, in little-endian
+        Tuple[int]: The next state of an ``n``-element system, in little-endian
         order unless ``big_endian`` is ``True``.
     """
     if n == 0:


### PR DESCRIPTION
This is a small downgrade (harmless as far as I can see) in how `tuple[Numbers.type]` annotations are written, with the goal of widening support to python 3.8, and current Google Colab kernels by transitivity.

Reference: https://stackoverflow.com/a/63460173

Sorry for the multiplicity of commits, I tried to catch all uses in advance but it was ultimately a trial-and-error back and forth.