### PR TITLE
Fixed Iterator issue

### DIFF
--- a/pyphi/db.py
+++ b/pyphi/db.py
@@ -7,7 +7,10 @@ Interface to MongoDB that exposes it as a key-value store.
 """
 
 import pickle
-from collections import Iterable
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 import pymongo
 from bson.binary import Binary


### PR DESCRIPTION
Fixed Iterator issue to work on all Python 3 versions now. Earlier it was broken for Python 3.10 and above.