### PR TITLE
Notebook for recording # of nodes and processing time

### DIFF
--- a/notebook/num_nodes_and_time.ipynb
+++ b/notebook/num_nodes_and_time.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "\n",
+    "import numpy as np\n",
+    "import pyphi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_nodes = 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(n_nodes, n_states) = (1, 2)\n",
+      "(n_nodes, n_states) = (2, 4)\n",
+      "(n_nodes, n_states) = (3, 8)\n",
+      "(n_nodes, n_states) = (4, 16)\n",
+      "(n_nodes, n_states) = (5, 32)\n",
+      "(n_nodes, n_states) = (6, 64)\n",
+      "(n_nodes, n_states) = (7, 128)\n",
+      "(n_nodes, n_states) = (8, 256)\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_nodes_max = 8\n",
+    "for n in range(1, n_nodes_max + 1):\n",
+    "    n_states = 2 ** n\n",
+    "    print(f\"(n_nodes, n_states) = {n, n_states}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(64, 64) 6\n"
+     ]
+    }
+   ],
+   "source": [
+    "def generate_states_with_binary_state(n_nodes, seed=42):\n",
+    "    \"\"\"\n",
+    "    Generates a matrix of random probabilities and a binary state vector with reproducibility.\n",
+    "    Each row of the random probabilities matrix sums to 1.\n",
+    "    The state vector is binary (0 or 1).\n",
+    "    \n",
+    "    Parameters:\n",
+    "    - n_nodes: The number of nodes.\n",
+    "    - seed: The seed for the random number generator to ensure reproducibility.\n",
+    "    \n",
+    "    Returns:\n",
+    "    - random_probs: A (2^n_nodes, 2^n_nodes) numpy array where each row sums to 1.\n",
+    "    - binary_state: A tuple representing a binary (0 or 1) state with n_nodes elements.\n",
+    "    \"\"\"\n",
+    "    np.random.seed(seed)\n",
+    "    \n",
+    "    matrix_size = 2 ** n_nodes\n",
+    "    \n",
+    "    # Generate random numbers for the matrix\n",
+    "    random_matrix = np.random.rand(matrix_size, matrix_size)\n",
+    "    # Normalize each row to sum to 1\n",
+    "    random_probs = random_matrix / random_matrix.sum(axis=1)[:, np.newaxis]\n",
+    "    \n",
+    "    # Generate the binary state vector\n",
+    "    binary_state_array = np.random.randint(2, size=(n_nodes, 1))\n",
+    "    binary_state = tuple(binary_state_array.flatten())\n",
+    "    \n",
+    "    return random_probs, binary_state\n",
+    "\n",
+    "# Generate with binary state\n",
+    "tpm, state = generate_states_with_binary_state(n_nodes, seed=42)\n",
+    "# print(tpm.shape, state.shape)\n",
+    "print(tpm.shape, len(state))\n",
+    "# print(tpm)\n",
+    "# print(\"===========\")\n",
+    "# print(state)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(2, 2, 2, 2, 2, 2, 6) (64, 64)\n"
+     ]
+    }
+   ],
+   "source": [
+    "sbn_tpm = pyphi.convert.state_by_state2state_by_node(tpm)\n",
+    "sbs_tpm = pyphi.convert.state_by_node2state_by_state(sbn_tpm)\n",
+    "\n",
+    "print(sbn_tpm.shape, sbs_tpm.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "φ_s = -8.904744115994914e-05\n",
+      "  Φ = 3.771928248186974\n"
+     ]
+    }
+   ],
+   "source": [
+    "pyphi.config.PROGRESS_BARS = False\n",
+    "pyphi.config.PARALLEL = False\n",
+    "pyphi.config.SHORTCIRCUIT_SIA = False\n",
+    "\n",
+    "# Defining a substrate\n",
+    "# node_labels = (\"A\", \"B\", \"C\")\n",
+    "\n",
+    "# TPM in state-by-node format (see `help(pyphi.Network)` for information on TPM\n",
+    "# representations).\n",
+    "# tpm = np.array(\n",
+    "#     [\n",
+    "#         [1, 0, 0],\n",
+    "#         [0, 1, 0],\n",
+    "#         [1, 1, 1],\n",
+    "#         [0, 1, 1],\n",
+    "#         [0, 0, 0],\n",
+    "#         [1, 1, 0],\n",
+    "#         [0, 0, 1],\n",
+    "#         [1, 0, 1],\n",
+    "#     ]\n",
+    "# )\n",
+    "\n",
+    "# The network's adjacency matrix. In its absence, PyPhi will assume all-to-all\n",
+    "# connectivity. PyPhi uses the \"from-to\" convention: a \"1\" in entry (i,j) means\n",
+    "# there is a directed edge from unit i to unit j.\n",
+    "\n",
+    "# NOTE: If the adjacency matrix indicates a connection between units when there\n",
+    "# is no causal connection according to the TPM, the analysis will correctly\n",
+    "# determine that; however, if the matrix specifies the *lack* of a connection,\n",
+    "# PyPhi will assume no causal influence and short-circuit the analysis, even if\n",
+    "# the TPM implies that there is.\n",
+    "# connectivity_matrix = np.array([\n",
+    "#     [1, 1, 0,],  # A->A, A->B\n",
+    "#     [0, 1, 1,],  # B->B, B->C\n",
+    "#     [1, 1, 1,],  # C->A, C->B, C->C\n",
+    "# ])\n",
+    "\n",
+    "# network = pyphi.Network(tpm, cm=connectivity_matrix, node_labels=node_labels)\n",
+    "# network = pyphi.Network(tpm)\n",
+    "network = pyphi.Network(sbs_tpm)\n",
+    "# network\n",
+    "# System Irreducibility Analysis: identifying complexes\n",
+    "## Intrinsicality: Define a candidate system\n",
+    "### A=ON, B=OFF, C=OFF (Abc in Figure 7).\n",
+    "# state = (1, 0, 0)\n",
+    "\n",
+    "# subsystem_backward = pyphi.Subsystem(\n",
+    "#     network,\n",
+    "#     state,\n",
+    "#     nodes=node_labels,\n",
+    "#     backward_tpm=True\n",
+    "# )\n",
+    "subsystem_backward = pyphi.Subsystem(\n",
+    "    network,\n",
+    "    state,\n",
+    "    backward_tpm=True\n",
+    ")\n",
+    "\n",
+    "# subsystem_forward = pyphi.Subsystem(\n",
+    "#     network,\n",
+    "#     state,\n",
+    "#     nodes=node_labels\n",
+    "# )\n",
+    "subsystem_forward = pyphi.Subsystem(\n",
+    "    network,\n",
+    "    state,\n",
+    ")\n",
+    "\n",
+    "## Composition: Unfolding Φ-structure\n",
+    "### Cause-effect structure and big Φ\n",
+    "phi_structure = pyphi.new_big_phi.phi_structure(subsystem_forward)\n",
+    "# phi_structure\n",
+    "\n",
+    "#### φ_s\n",
+    "print(f\"φ_s = {phi_structure.sia.phi}\")\n",
+    "\n",
+    "#### Big Φ (sum of distinctions and relations' small φ)\n",
+    "print(f\"  Φ = {phi_structure.big_phi}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'\\n4 nodes: 5.8s\\n5 nodes: 2m31.9s\\n'"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "4 nodes: 5.8s\n",
+    "5 nodes: 2m31.9s\n",
+    "6 nodes: 133m19.7s\n",
+    "\"\"\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "iit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebook/num_nodes_and_time.ipynb
+++ b/notebook/num_nodes_and_time.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U git+https://github.com/wmayner/pyphi.git@feature/iit-4.0"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
# PR Summary
In response to #115, I created a short notebook for recording the number of nodes `n` in a network and the processing time spent on a simple analysis.
# Details
## Workflow
1. Generate a `(2^n,2^n)` state-by-state TPM and its single binary state of `n` nodes
2. Run through [there_and_back_again](https://github.com/wmayner/pyphi/blob/83e887db466ed0c617cfb637f94a13d2aae8eea2/pyphi/tpm.py#L340) processing to avoid conditional dependence issue
3. As an example use case, substrate phi and big phi are calculated
## Answer to #115
As is commented, the processing time on the analysis looks quadratic to `n`.
Since 6 nodes (2^6=64*64 state-by-state TPM) calculation takes around 2 hours and 8 nodes takes forever, I believe 6-7 nodes is the upper bound for the tractable analysis.