### PR TITLE
Fix purview plotting bug

### DIFF
--- a/pyphi/visualize/phi_structure/__init__.py
+++ b/pyphi/visualize/phi_structure/__init__.py
@@ -134,6 +134,8 @@ def plot_phi_structure(
             mechanism_mapping,
             **theme["geometry"]["mechanisms"].get("coordinate_kwargs", dict()),
         )
+    else:
+        mechanism_mapping = mechanism_coords.mapping
 
     purview_mapping = theme["geometry"]["purviews"].get("mapping")
     if purview_mapping is None:


### PR DESCRIPTION
Made it so that when plotting purviews with arrange_by_mechanism, if mechanism coords are specified, then plot purviews by those coords