### PR TITLE
Optional argument to limit `repertoire.forward_cause_repertoire()` to specified purview state

### DIFF
--- a/pyphi/new_big_phi/__init__.py
+++ b/pyphi/new_big_phi/__init__.py
@@ -208,7 +208,10 @@ def integration_value(
     # TODO(4.0) deal with proliferation of special cases for GID
     if repertoire_distance == "GENERALIZED_INTRINSIC_DIFFERENCE":
         partitioned_repertoire = cut_subsystem.forward_repertoire(
-            direction, subsystem.node_indices, subsystem.node_indices
+            direction,
+            subsystem.node_indices,
+            subsystem.node_indices,
+            system_state[direction].state,
         ).squeeze()[system_state[direction].state]
     else:
         partitioned_repertoire = cut_subsystem.repertoire(

--- a/pyphi/repertoire.py
+++ b/pyphi/repertoire.py
@@ -64,7 +64,10 @@ def forward_cause_repertoire(
     mechanism_state = utils.state_of(mechanism, subsystem.state)
     if purview:
         repertoire = np.empty([2] * len(purview))
-        purview_states = utils.all_states(len(purview))
+        if purview_state is None:
+            purview_states = utils.all_states(len(purview))
+        else:
+            purview_states = [purview_state]
     else:
         repertoire = np.array([1])
         purview_states = [()]
@@ -107,7 +110,7 @@ def unconstrained_forward_cause_repertoire(
     # equal to the average value over all `Z`. So we compute this average value
     # and fill the repertoire with it.
     mean_forward_cause_probability = subsystem.forward_cause_repertoire(
-        mechanism, purview
+        mechanism, purview, None
     ).mean()
     repertoire = np.empty(repertoire_shape(subsystem.network.node_indices, purview))
     repertoire.fill(mean_forward_cause_probability)

--- a/pyphi/subsystem.py
+++ b/pyphi/subsystem.py
@@ -574,19 +574,29 @@ class Subsystem:
         )
 
     def forward_repertoire(
-        self, direction: Direction, mechanism: Tuple[int], purview: Tuple[int], **kwargs
+        self,
+        direction: Direction,
+        mechanism: Tuple[int],
+        purview: Tuple[int],
+        purview_state: Tuple[int],
+        **kwargs,
     ) -> ArrayLike:
         if direction == Direction.CAUSE:
-            return self.forward_cause_repertoire(mechanism, purview)
+            return self.forward_cause_repertoire(mechanism, purview, purview_state)
         elif direction == Direction.EFFECT:
             return self.forward_effect_repertoire(mechanism, purview, **kwargs)
         return validate.direction(direction)
 
     @cache.method("_forward_repertoire_cache", Direction.CAUSE)
     def forward_cause_repertoire(
-        self, mechanism: Tuple[int], purview: Tuple[int]
+        self, mechanism: Tuple[int], purview: Tuple[int], purview_state
     ) -> ArrayLike:
-        return _repertoire.forward_cause_repertoire(self, mechanism, purview)
+        return _repertoire.forward_cause_repertoire(
+            self,
+            mechanism,
+            purview,
+            purview_state=purview_state,
+        )
 
     # NOTE: No caching is required here because the forward effect repertoire is
     # the same as the effect repertoire.
@@ -992,6 +1002,7 @@ class Subsystem:
                 direction,
                 mechanism,
                 purview,
+                None,
             )
             unconstrained_repertoire = self.unconstrained_forward_repertoire(
                 direction,


### PR DESCRIPTION
And use it at `new_big_phi.integration_value()` to avoid rebuilding the whole repertoire for each partition, given that intrinsic information has already computed the specified cause state.

`new_big_phi.system_intrinsic_information()`, `subsystem.intrinsic_information()` and rest still reuse the same function in `repertoire`.

Implemented as positional argument instead of keyword in `subsystem.forward_cause_repertoire()` signature, in order to keep the cache working.

No change in test suite before and after, but we might want to update serialized data after the latest pyphi version bump (disabling the JSON version exception makes all tests pass):

```
================================ short test summary info ================================FAILED test/test_iit4.py::test[basic] - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
FAILED test/test_iit4.py::test[basic_noisy_selfloop] - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
FAILED test/test_iit4.py::test[fig4] - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
FAILED test/test_iit4.py::test[grid3] - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
FAILED test/test_iit4.py::test[xor] - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_standard_example_sequential - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_standard_example_parallel - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_standard_example_complete_parallel - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_noised_example_sequential - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_noised_example_parallel - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_micro_sequential - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_micro_parallel - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_big_network_0_thru_3_sequential - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_big_network_0_thru_3_parallel - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_macro_sequential - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
ERROR test/test_big_phi.py::test_sia_macro_parallel - pyphi.exceptions.JSONVersionError: Cannot load JSON from a different version of PyPh...
==== 5 failed, 629 passed, 56 skipped, 16 deselected, 2 xfailed, 11 errors in 34.90s ====
```